### PR TITLE
Add  Flink Operator Bakery

### DIFF
--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -26,7 +26,12 @@ jobs:
 
     - name: Setup FlinkOperator
       run: |
-        helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-1.1.0
+        # Setup cert-manager, required by Flink Operator
+        CERT_MANAGER_VERSION=1.9.1
+        kubectl create -f https://github.com/jetstack/cert-manager/releases/download/v${CERT_MANAGER_VERSION}/cert-manager.yaml
+
+        FLINK_OPERATOR_VERSION=1.1.0
+        helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-${FLINK_OPERATOR_VERSION}
         helm install flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator --wait
 
         kubectl get pod -A

--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -50,7 +50,7 @@ jobs:
       run: |
         helm repo add minio https://charts.min.io/
         helm install minio minio/minio \
-          --set rootUser=root,rootPassword=root
+          --set rootUser=root,rootPassword=root || true
 
         kubectl get pod -A
         kubectl get svc -A

--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -80,7 +80,7 @@ jobs:
     - name: Install socat so kubectl port-forward will work
       run: |
         # Not sure if this is why kubectl proxy isn't working, but let's try
-        apt update --yes && apt install --yes socat
+        sudo apt update --yes && sudo apt install --yes socat
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -76,6 +76,12 @@ jobs:
         python -m pip install -r dev-requirements.txt
         python -m pip install -e .
 
+
+    - name: Install socat so kubectl port-forward will work
+      run: |
+        # Not sure if this is why kubectl proxy isn't working, but let's try
+        apt update --yes && apt install --yes socat
+
     - name: Test with pytest
       run: |
         pytest -vvv -s --cov=pangeo_forge_runner tests/test_flink.py || true

--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -50,11 +50,11 @@ jobs:
       run: |
         helm repo add minio https://charts.min.io/
         helm install minio minio/minio \
-          --set rootUser=root,rootPassword=root \
-          --wait
+          --set rootUser=root,rootPassword=root
 
         kubectl get pod -A
         kubectl get svc -A
+        kubectl wait pod --all
 
     - name: 'Set up Cloud SDK'
       uses: 'google-github-actions/setup-gcloud@v0'

--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -86,3 +86,6 @@ jobs:
         pytest -vvv -s --cov=pangeo_forge_runner tests/test_flink.py
         kubectl get pod -A
         kubectl describe pod
+
+    - name: Upload Coverage to Codecov
+      uses: codecov/codecov-action@v2

--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -35,6 +35,7 @@ jobs:
       with:
         timeout: 150
         max-restarts: 1
+        namespace: cert-manager
 
     - name: Setup FlinkOperator
       run: |

--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -78,4 +78,5 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest -vvv -s --cov=pangeo_forge_runner tests/test_flink.py
+        pytest -vvv -s --cov=pangeo_forge_runner tests/test_flink.py || true
+        k get pod -A

--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -55,9 +55,27 @@ jobs:
       with:
         python-version: 3.9
 
+    - name: 'Setup minio + mc'
+      run: |
+        wget --quiet https://dl.min.io/server/minio/release/linux-amd64/minio
+        chmod +x minio
+        mv minio /usr/local/bin/minio
+
+        wget --quiet https://dl.min.io/client/mc/release/linux-amd64/mc
+        chmod +x mc
+        mv mc /usr/local/bin/mc
+
+        minio --version
+        mc --version
+
+
 
     - name: Install dependencies & our package
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r dev-requirements.txt
         python -m pip install -e .
+
+    - name: Test with pytest
+      run: |
+        pytest -vvv -s --cov=pangeo_forge_runner tests/test_flink.py

--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -46,6 +46,16 @@ jobs:
         kubectl get pod -A
         kubectl get crd -A
 
+    - name: Setup minio
+      run: |
+        helm repo add minio https://charts.min.io/
+        helm install minio minio/minio \
+          --set rootUser=root,rootPassword=root \
+          --wait
+
+        kubectl get pod -A
+        kubectl get svc -A
+
     - name: 'Set up Cloud SDK'
       uses: 'google-github-actions/setup-gcloud@v0'
 

--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -28,7 +28,7 @@ jobs:
       run: |
         # Setup cert-manager, required by Flink Operator
         CERT_MANAGER_VERSION=1.9.1
-        kubectl create -f https://github.com/jetstack/cert-manager/releases/download/v${CERT_MANAGER_VERSION}/cert-manager.yaml
+        kubectl apply --wait -f https://github.com/jetstack/cert-manager/releases/download/v${CERT_MANAGER_VERSION}/cert-manager.yaml
 
         FLINK_OPERATOR_VERSION=1.1.0
         helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-${FLINK_OPERATOR_VERSION}

--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -24,15 +24,29 @@ jobs:
         traefik-enabled: false
         docker-enabled: true
 
-    - name: Setup FlinkOperator
+    - name: Setup CertManager
       run: |
         # Setup cert-manager, required by Flink Operator
         CERT_MANAGER_VERSION=1.9.1
-        kubectl apply --wait -f https://github.com/jetstack/cert-manager/releases/download/v${CERT_MANAGER_VERSION}/cert-manager.yaml
+        kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v${CERT_MANAGER_VERSION}/cert-manager.yaml
 
+    - name: Wait for CertManager to be ready
+      uses: jupyterhub/action-k8s-await-workloads@v1
+      with:
+        timeout: 150
+        max-restarts: 1
+
+    - name: Setup FlinkOperator
+      run: |
         FLINK_OPERATOR_VERSION=1.1.0
         helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-${FLINK_OPERATOR_VERSION}
         helm install flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator --wait
 
         kubectl get pod -A
         kubectl get crd -A
+
+    - name: Wait for FlinkOperator to be ready
+      uses: jupyterhub/action-k8s-await-workloads@v1
+      with:
+        timeout: 150
+        max-restarts: 1

--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -46,8 +46,18 @@ jobs:
         kubectl get pod -A
         kubectl get crd -A
 
-    - name: Wait for FlinkOperator to be ready
-      uses: jupyterhub/action-k8s-await-workloads@v1
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v0'
+
+
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v3
       with:
-        timeout: 150
-        max-restarts: 1
+        python-version: 3.9
+
+
+    - name: Install dependencies & our package
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r dev-requirements.txt
+        python -m pip install -e .

--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -50,7 +50,12 @@ jobs:
       run: |
         helm repo add minio https://charts.min.io/
         helm install minio minio/minio \
-          --set rootUser=root,rootPassword=root || true
+          --set rootUser=root \
+          --set rootPassword=root \
+          --set mode=standalone \
+          --set replicas=1 \
+          --set persistence.enabled=false \
+          --set resources.requests.memory=32Mi || true
 
         kubectl get pod -A
         kubectl get svc -A

--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -69,7 +69,6 @@ jobs:
         mc --version
 
 
-
     - name: Install dependencies & our package
       run: |
         python -m pip install --upgrade pip
@@ -84,6 +83,6 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest -vvv -s --cov=pangeo_forge_runner tests/test_flink.py || true
+        pytest -vvv -s --cov=pangeo_forge_runner tests/test_flink.py
         kubectl get pod -A
         kubectl describe pod

--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -49,9 +49,10 @@ jobs:
     - name: Setup minio
       run: |
         helm repo add minio https://charts.min.io/
+        # rootPassword needs to be at least 8 chars long!
         helm install minio minio/minio \
           --set rootUser=root \
-          --set rootPassword=root \
+          --set rootPassword=rootpassword \
           --set mode=standalone \
           --set replicas=1 \
           --set persistence.enabled=false \

--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -86,3 +86,4 @@ jobs:
       run: |
         pytest -vvv -s --cov=pangeo_forge_runner tests/test_flink.py || true
         kubectl get pod -A
+        kubectl describe pod

--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -46,22 +46,6 @@ jobs:
         kubectl get pod -A
         kubectl get crd -A
 
-    - name: Setup minio
-      run: |
-        helm repo add minio https://charts.min.io/
-        # rootPassword needs to be at least 8 chars long!
-        helm install minio minio/minio \
-          --wait \
-          --set rootUser=root \
-          --set rootPassword=rootpassword \
-          --set mode=standalone \
-          --set replicas=1 \
-          --set persistence.enabled=false \
-          --set resources.requests.memory=32Mi
-
-        kubectl get pod -A
-        kubectl get svc -A
-
     - name: 'Set up Cloud SDK'
       uses: 'google-github-actions/setup-gcloud@v0'
 

--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -85,4 +85,4 @@ jobs:
     - name: Test with pytest
       run: |
         pytest -vvv -s --cov=pangeo_forge_runner tests/test_flink.py || true
-        k get pod -A
+        kubectl get pod -A

--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -1,0 +1,33 @@
+name: Run Flink Test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    # Starts a k8s cluster with NetworkPolicy enforcement and installs both
+    # kubectl and helm
+    #
+    # ref: https://github.com/jupyterhub/action-k3s-helm/
+    - uses: jupyterhub/action-k3s-helm@v3
+      with:
+        metrics-enabled: false
+        traefik-enabled: false
+        docker-enabled: true
+
+    - name: Setup FlinkOperator
+      run: |
+        helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-1.1.0
+        helm install flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator --wait
+
+        kubectl get pod -A
+        kubectl get crd -A

--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -51,16 +51,16 @@ jobs:
         helm repo add minio https://charts.min.io/
         # rootPassword needs to be at least 8 chars long!
         helm install minio minio/minio \
+          --wait \
           --set rootUser=root \
           --set rootPassword=rootpassword \
           --set mode=standalone \
           --set replicas=1 \
           --set persistence.enabled=false \
-          --set resources.requests.memory=32Mi || true
+          --set resources.requests.memory=32Mi
 
         kubectl get pod -A
         kubectl get svc -A
-        kubectl wait pod --all
 
     - name: 'Set up Cloud SDK'
       uses: 'google-github-actions/setup-gcloud@v0'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -45,23 +45,5 @@ jobs:
       run: |
         pytest -vvv -s --cov=pangeo_forge_runner tests/
 
-    # Starts a k8s cluster with NetworkPolicy enforcement and installs both
-    # kubectl and helm
-    #
-    # ref: https://github.com/jupyterhub/action-k3s-helm/
-    - uses: jupyterhub/action-k3s-helm@v3
-      with:
-        metrics-enabled: false
-        traefik-enabled: false
-        docker-enabled: true
-
-    - name: Setup FlinkOperator
-      run: |
-        helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-1.1.0
-        helm install flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator --wait
-
-        kubectl get pod -A
-        kubectl get crd -A
-
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -41,9 +41,11 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install -r dev-requirements.txt
         python -m pip install -e .
+
     - name: Test with pytest
       run: |
-        pytest -vvv -s --cov=pangeo_forge_runner tests/
+        # Test everything except the flink tests
+        pytest -vvv -s --cov=pangeo_forge_runner --ignore=tests/test_flink.py tests/
 
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -44,5 +44,24 @@ jobs:
     - name: Test with pytest
       run: |
         pytest -vvv -s --cov=pangeo_forge_runner tests/
+
+    # Starts a k8s cluster with NetworkPolicy enforcement and installs both
+    # kubectl and helm
+    #
+    # ref: https://github.com/jupyterhub/action-k3s-helm/
+    - uses: jupyterhub/action-k3s-helm@v3
+      with:
+        metrics-enabled: false
+        traefik-enabled: false
+        docker-enabled: true
+
+    - name: Setup FlinkOperator
+      run: |
+        helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-1.1.0
+        helm install flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator --wait
+
+        kubectl get pod -A
+        kubectl get crd -A
+
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v2

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,14 @@
 Commandline tool to manage [pangeo-forge](https://pangeo-forge.readthedocs.io/en/latest/)
 feedstocks
 
+## Tutorials
+
+```{toctree}
+:maxdepth: 1
+
+tutorial/flink
+```
+
 ## Contents
 
 ```{toctree}

--- a/docs/tutorial/flink.md
+++ b/docs/tutorial/flink.md
@@ -1,0 +1,74 @@
+# Run a recipe on a Flink cluster on AWS
+
+## Setting up your local machine
+
+1. Install required tools on your machine.
+   1. [aws](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+   2. [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
+
+2. Authenticate to `aws` by running `aws configure`. If you don't already have the
+   AWS Access Keys, you might need to [create one](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_CreateAccessKey).
+
+3. Get credentials access to the kubernetes cluster by running
+   `aws eks update-kubeconfig --name=<cluster-name> --region=<region>`.
+
+   You can verify this works by running `kubectl get pod` - it should succeed,
+   and show you that at least a `flink-kubernetes-operator` pod is running.
+
+## Setting up configuration
+
+Construct a `pangeo_forge_runner.py` that will have configuration on *where*
+the data should *end up in*. In our case, we will use S3. You must already have
+created an S3 bucket for this to work.
+
+```python
+# Let's put all our data into s3, partitioned by the id of each job we run
+BUCKET_PREFIX = "s3://<bucket-name>/<some-prefix>/{job_id}"
+
+c.TargetStorage.fsspec_class = "s3fs.S3FileSystem"
+c.TargetStorage.root_path = f"{BUCKET_PREFIX}/output"
+c.TargetStorage.fsspec_args = {
+    "key": "<your-aws-access-key>",
+    "secret": "<your-aws-access-secret>",
+
+}
+
+c.InputCacheStorage.fsspec_class = c.TargetStorage.fsspec_class
+c.InputCacheStorage.fsspec_args = c.TargetStorage.fsspec_args
+c.InputCacheStorage.root_path = f"{BUCKET_PREFIX}/cache/input"
+
+c.MetadataCacheStorage.fsspec_class = c.TargetStorage.fsspec_class
+c.MetadataCacheStorage.fsspec_args = c.TargetStorage.fsspec_args
+c.MetadataCacheStorage.root_path = f"{BUCKET_PREFIX}/cache/metadata"
+```
+
+
+## Running the recipe
+
+Now run a recipe!
+
+```bash
+pangeo-forge-runner bake --repo <url-to-github-repo> --ref <name-of-branch-or-commit-hash>
+```
+
+You can add `--prune` if you want to only test the recipe and run just the first
+few steps.
+
+This might take a minute to submit, and you should start seeing
+
+## Access the Flink Dashboard
+
+After you run the `pangeo-forge-runner` command, amongst the many lines of output,
+you should see something that looks like:
+
+`You can run 'kubectl port-forward --pod-running-timeout=2m0s --address 127.0.0.1 <some-name> 0:8081' to make the Flink Dashboard available!`
+
+If you copy the command provided in the message and run it, it should provide you
+with a local address where the Flink Dashboard will be available!
+
+```
+$ kubectl port-forward --pod-running-timeout=2m0s --address 127.0.0.1 <some-name> 0:8081
+Forwarding from 127.0.0.1:<some-number> -> 8081
+```
+
+Copy the `127.0.0.1:<some-number>` URL to your browser, and tada!

--- a/docs/tutorial/flink.md
+++ b/docs/tutorial/flink.md
@@ -1,5 +1,21 @@
 # Run a recipe on a Flink cluster on AWS
 
+`pangeo-forge-runner` supports baking your recipes on Apache Flink using
+the [Apache Flink Runner](https://beam.apache.org/documentation/runners/flink/)
+for Beam. After looking at various options, we have settled on supporting
+Flink on Kubernetes using Apache's [Flink Operator](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/).
+This would allow baking recipes on *any* Kubernetes cluster!
+
+In this tutorial, we'll bake a recipe on a Amazon [EKS](https://aws.amazon.com/eks/)
+kubernetes cluster!
+
+## Setting up the cluster
+
+You need an EKS cluster with [Apache Flink Operator](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/)
+installed. Setting that up is out of the scope for this tutorial, but you can find some
+useful terraform scripts for that [here](https://github.com/yuvipanda/pangeo-forge-cloud-federation/)
+if you wish.
+
 ## Setting up your local machine
 
 1. Install required tools on your machine.
@@ -54,7 +70,7 @@ pangeo-forge-runner bake --repo <url-to-github-repo> --ref <name-of-branch-or-co
 You can add `--prune` if you want to only test the recipe and run just the first
 few steps.
 
-This might take a minute to submit, and you should start seeing
+This might take a minute to submit.
 
 ## Access the Flink Dashboard
 

--- a/pangeo_forge_runner/bakery/flink.py
+++ b/pangeo_forge_runner/bakery/flink.py
@@ -76,7 +76,7 @@ class FlinkOperatorBakery(Bakery):
     )
 
     job_manager_resources = Dict(
-        {"memory": "1024m"},
+        {"memory": "1024m", "cpu": 0.2},
         config=True,
         help="""
         Memory & CPU resources to give to the jobManager pod.
@@ -92,7 +92,7 @@ class FlinkOperatorBakery(Bakery):
     )
 
     task_manager_resources = Dict(
-        {"memory": "1024m"},
+        {"memory": "1024m", "cpu": 0.2},
         config=True,
         help="""
         Memory & CPU resources to give to the taskManager container.

--- a/pangeo_forge_runner/bakery/flink.py
+++ b/pangeo_forge_runner/bakery/flink.py
@@ -97,9 +97,9 @@ class FlinkOperatorBakery(Bakery):
                                     "image": worker_image,
                                     "ports": [{"containerPort": 50000}],
                                     "readinessProbe": {
+                                        # Don't mark this container as ready until the beam SDK harnass starts
                                         "tcpSocket": {"port": 50000},
-                                        "initialDelaySeconds": 30,
-                                        "periodSeconds": 60,
+                                        "periodSeconds": 10,
                                     },
                                     "command": ["/opt/apache/beam/boot"],
                                     "args": ["--worker_pool"],

--- a/pangeo_forge_runner/bakery/flink.py
+++ b/pangeo_forge_runner/bakery/flink.py
@@ -8,7 +8,7 @@ import subprocess
 import tempfile
 
 from apache_beam.pipeline import PipelineOptions
-from traitlets import Unicode
+from traitlets import Dict, Unicode
 
 from .base import Bakery
 
@@ -51,10 +51,22 @@ class FlinkOperatorBakery(Bakery):
     flink_version = Unicode(
         "1.15",
         config=True,
-        description="""
+        help="""
         Version of Flink to use.
 
         Must be a version supported by the Flink Operator installed in the cluster
+        """,
+    )
+
+    flink_configuration = Dict(
+        {"taskmanager.numberOfTaskSlots": "2"},
+        config=True,
+        help="""
+        Properties to set as Flink configuration.
+
+        See https://nightlies.apache.org/flink/flink-docs-stable/docs/deployment/config/
+        for full list of configuration options. Make sure you are looking at the right
+        setup for the version of Flink you are using.
         """,
     )
 
@@ -71,7 +83,7 @@ class FlinkOperatorBakery(Bakery):
             "spec": {
                 "image": image,
                 "flinkVersion": flink_version_str,
-                "flinkConfiguration": {"taskmanager.numberOfTaskSlots": "2"},
+                "flinkConfiguration": self.flink_configuration,
                 "serviceAccount": "flink",
                 "jobManager": {"resource": {"memory": "2048m", "cpu": 1}},
                 "taskManager": {

--- a/pangeo_forge_runner/bakery/flink.py
+++ b/pangeo_forge_runner/bakery/flink.py
@@ -3,6 +3,7 @@ Bakery for baking pangeo-forge recipes in GCP DataFlow
 """
 import hashlib
 import json
+import shutil
 import subprocess
 import tempfile
 
@@ -101,6 +102,10 @@ class FlinkBakery(Bakery):
         """
         Return PipelineOptions for use with this Bakery
         """
+
+        # We use `kubectl` to talk to kubernetes, so let's make sure it exists
+        if shutil.which("kubectl") is None:
+            raise ValueError("kubectl is required for FlinkBakery to work")
 
         # Flink cluster names have a 45 char limit
         cluster_name = generate_hashed_slug(job_name, 45)

--- a/pangeo_forge_runner/bakery/flink.py
+++ b/pangeo_forge_runner/bakery/flink.py
@@ -1,0 +1,37 @@
+"""
+Bakery for baking pangeo-forge recipes in GCP DataFlow
+"""
+from apache_beam.pipeline import PipelineOptions
+from traitlets import Bool, TraitError, Unicode, default, validate
+
+from .base import Bakery
+
+
+class FlinkBakery(Bakery):
+    """
+    Bake a Pangeo Forge recipe on a Flink cluster
+    """
+
+    def get_pipeline_options(
+        self, job_name: str, container_image: str
+    ) -> PipelineOptions:
+        """
+        Return PipelineOptions for use with this Bakery
+        """
+
+        # Set flags explicitly to empty so Apache Beam doesn't try to parse the commandline
+        # for pipeline options - we have traitlets doing that for us.
+        opts = dict(
+            flags=[],
+            runner="FlinkRunner",
+            # FIXME: This should be the deployed flink master URL
+            flink_master='127.0.0.1:8081',
+            flink_submit_uber_jar=True,
+            environment_type='EXTERNAL',
+            environment_config='0.0.0.0:50000',
+            # https://cloud.google.com/dataflow/docs/resources/faq#how_do_i_handle_nameerrors
+            save_main_session=True,
+            # this might solve serialization issues; cf. https://beam.apache.org/blog/beam-2.36.0/
+            pickle_library="cloudpickle",
+        )
+        return PipelineOptions(**opts)

--- a/pangeo_forge_runner/bakery/flink.py
+++ b/pangeo_forge_runner/bakery/flink.py
@@ -229,7 +229,8 @@ class FlinkOperatorBakery(Bakery):
         listen_address = line.split(" ")[2]
         # Use rsplit in case we listen on ipv6 stuff in the future
         listen_port = listen_address.rsplit(":", 1)[1]
-        print(f"You can see the flink dashboard at http://127.0.0.1:{listen_port}")
+
+        print(f"You can run '{' '.join(cmd)}' to make the Flink Dashboard available!")
 
         # Set flags explicitly to empty so Apache Beam doesn't try to parse the commandline
         # for pipeline options - we have traitlets doing that for us.

--- a/pangeo_forge_runner/bakery/flink.py
+++ b/pangeo_forge_runner/bakery/flink.py
@@ -49,6 +49,10 @@ class FlinkOperatorBakery(Bakery):
     installed
     """
 
+    # Not actually, but we don't have a job_id to return.
+    # that looks like just a dataflow concept, we'll have to refactor
+    blocking = True
+
     flink_version = Unicode(
         "1.15",
         config=True,

--- a/pangeo_forge_runner/bakery/flink.py
+++ b/pangeo_forge_runner/bakery/flink.py
@@ -90,10 +90,10 @@ class FlinkOperatorBakery(Bakery):
                 "flinkVersion": flink_version_str,
                 "flinkConfiguration": self.flink_configuration,
                 "serviceAccount": "flink",
-                "jobManager": {"resource": {"memory": "2048m", "cpu": 1}},
+                "jobManager": {"resource": {"memory": "1024m", "cpu": 0.2}},
                 "taskManager": {
                     "replicas": 5,
-                    "resource": {"memory": "2048m", "cpu": 1},
+                    "resource": {"memory": "1024m", "cpu": 0.2},
                     "podTemplate": {
                         "spec": {
                             "containers": [

--- a/pangeo_forge_runner/bakery/flink.py
+++ b/pangeo_forge_runner/bakery/flink.py
@@ -1,16 +1,99 @@
 """
 Bakery for baking pangeo-forge recipes in GCP DataFlow
 """
+import hashlib
+import json
+import subprocess
+import tempfile
+
 from apache_beam.pipeline import PipelineOptions
-from traitlets import Bool, TraitError, Unicode, default, validate
+from traitlets import Unicode
 
 from .base import Bakery
+
+
+# Copied from https://github.com/jupyterhub/kubespawner/blob/7d6d82c2be469dd76f770d6f6ed0d1dade6b24a7/kubespawner/utils.py#L8
+# But I wrote it there too - is it really stealing if you're stealing from yourself?
+def generate_hashed_slug(slug, limit=63, hash_length=6):
+    """
+    Generate a unique name that's within a certain length limit
+
+    Most k8s objects have a 63 char name limit. We wanna be able to compress
+    larger names down to that if required, while still maintaining some
+    amount of legibility about what the objects really are.
+
+    If the length of the slug is shorter than the limit - hash_length, we just
+    return slug directly. If not, we truncate the slug to (limit - hash_length)
+    characters, hash the slug and append hash_length characters from the hash
+    to the end of the truncated slug. This ensures that these names are always
+    unique no matter what.
+    """
+    if len(slug) < (limit - hash_length):
+        return slug
+
+    slug_hash = hashlib.sha256(slug.encode("utf-8")).hexdigest()
+
+    return "{prefix}-{hash}".format(
+        prefix=slug[: limit - hash_length - 1],
+        hash=slug_hash[:hash_length],
+    ).lower()
 
 
 class FlinkBakery(Bakery):
     """
     Bake a Pangeo Forge recipe on a Flink cluster
     """
+
+    flink_version = Unicode(
+        "1.15",
+        config=True,
+        description="""
+        Version of Flink to use.
+
+        Must be a version supported by the Flink Operator installed in the cluster
+        """,
+    )
+
+    def make_flink_deployment(self, name: str, worker_image: str):
+        """
+        Return YAML for a FlinkDeployment
+        """
+        image = f"flink:{self.flink_version}"
+        flink_version_str = f'v{self.flink_version.replace(".", "_")}'
+        return {
+            "apiVersion": "flink.apache.org/v1beta1",
+            "kind": "FlinkDeployment",
+            "metadata": {"name": name},
+            "spec": {
+                "image": image,
+                "flinkVersion": flink_version_str,
+                "flinkConfiguration": {"taskmanager.numberOfTaskSlots": "2"},
+                "serviceAccount": "flink",
+                "jobManager": {"resource": {"memory": "2048m", "cpu": 1}},
+                "taskManager": {
+                    "replicas": 5,
+                    "resource": {"memory": "2048m", "cpu": 1},
+                    "podTemplate": {
+                        "spec": {
+                            "containers": [
+                                {
+                                    "name": "beam-worker-pool",
+                                    "image": worker_image,
+                                    "ports": [{"containerPort": 50000}],
+                                    "readinessProbe": {
+                                        "tcpSocket": {"port": 50000},
+                                        "initialDelaySeconds": 30,
+                                        "periodSeconds": 60,
+                                    },
+                                    "command": ["/opt/apache/beam/boot"],
+                                    "args": ["--worker_pool"],
+                                }
+                            ]
+                        }
+                    },
+                },
+            },
+        }
 
     def get_pipeline_options(
         self, job_name: str, container_image: str
@@ -19,16 +102,61 @@ class FlinkBakery(Bakery):
         Return PipelineOptions for use with this Bakery
         """
 
+        # Flink cluster names have a 45 char limit
+        cluster_name = generate_hashed_slug(job_name, 45)
+
+        # Create the temp flink cluster
+        with tempfile.NamedTemporaryFile(mode="w") as f:
+            f.write(
+                json.dumps(self.make_flink_deployment(cluster_name, container_image))
+            )
+            f.flush()
+            # FIXME: Add a timeout here?
+            cmd = ["kubectl", "apply", "-f", f.name]
+            subprocess.check_call(cmd)
+
+        # Wait for the cluster to be ready
+        cmd = [
+            "kubectl",
+            "wait",
+            f"flinkdeployments.flink.apache.org/{cluster_name}",
+            "--for=jsonpath=.status.jobManagerDeploymentStatus=READY",
+        ]
+        subprocess.check_call(cmd)
+
+        # port-forward the thing
+        cmd = [
+            "kubectl",
+            "port-forward",
+            "--pod-running-timeout=2m0s",
+            "--address",
+            "127.0.0.1",  # Just ipv4 tx
+            f"svc/{cluster_name}-rest",
+            # 0 will allocate a random local port
+            "0:8081",
+        ]
+        # Let's read out the line of output from kubectl so we can figure out what port
+        # `kubectl` has bound to
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+        line = p.stdout.readline().decode()
+        # I could use regex here, but then I'll have two problems (at least)
+        # The line provided by kubectl looks like `Forwarding from 127.0.0.1:59408 -> 8081`
+        # We just want the randomly generated port there
+        listen_address = line.split(" ")[2]
+        # Use rsplit in case we listen on ipv6 stuff in the future
+        listen_port = listen_address.rsplit(":", 1)[1]
+        print(f"You can see the flink dashboard at http://127.0.0.1:{listen_port}")
+
         # Set flags explicitly to empty so Apache Beam doesn't try to parse the commandline
         # for pipeline options - we have traitlets doing that for us.
         opts = dict(
             flags=[],
             runner="FlinkRunner",
             # FIXME: This should be the deployed flink master URL
-            flink_master='127.0.0.1:8081',
+            flink_master=f"127.0.0.1:{listen_port}",
             flink_submit_uber_jar=True,
-            environment_type='EXTERNAL',
-            environment_config='0.0.0.0:50000',
+            environment_type="EXTERNAL",
+            environment_config="0.0.0.0:50000",
             # https://cloud.google.com/dataflow/docs/resources/faq#how_do_i_handle_nameerrors
             save_main_session=True,
             # this might solve serialization issues; cf. https://beam.apache.org/blog/beam-2.36.0/

--- a/pangeo_forge_runner/bakery/flink.py
+++ b/pangeo_forge_runner/bakery/flink.py
@@ -6,6 +6,7 @@ import json
 import shutil
 import subprocess
 import tempfile
+import time
 
 from apache_beam.pipeline import PipelineOptions
 from traitlets import Dict, Unicode
@@ -138,6 +139,7 @@ class FlinkOperatorBakery(Bakery):
             cmd = ["kubectl", "apply", "--wait", "-f", f.name]
             subprocess.check_call(cmd)
 
+        time.sleep(2)
         # Wait for the cluster to be ready
         cmd = [
             "kubectl",

--- a/pangeo_forge_runner/bakery/flink.py
+++ b/pangeo_forge_runner/bakery/flink.py
@@ -143,7 +143,7 @@ class FlinkOperatorBakery(Bakery):
             cmd = ["kubectl", "apply", "--wait", "-f", f.name]
             subprocess.check_call(cmd)
 
-        time.sleep(2)
+        time.sleep(5)
         # Wait for the cluster to be ready
         cmd = [
             "kubectl",

--- a/pangeo_forge_runner/bakery/flink.py
+++ b/pangeo_forge_runner/bakery/flink.py
@@ -76,7 +76,7 @@ class FlinkOperatorBakery(Bakery):
     )
 
     job_manager_resources = Dict(
-        {},
+        {"memory": "1024m"},
         config=True,
         help="""
         Memory & CPU resources to give to the jobManager pod.
@@ -86,11 +86,13 @@ class FlinkOperatorBakery(Bakery):
         See https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/custom-resource/reference/#resource
         for accepted keys and what they mean. Specifically, note that this is *not*
         specified the same way as kubernetes resource requests in general.
+
+        Note that at least memory *must* be set.
         """,
     )
 
     task_manager_resources = Dict(
-        {},
+        {"memory": "1024m"},
         config=True,
         help="""
         Memory & CPU resources to give to the taskManager container.
@@ -104,6 +106,8 @@ class FlinkOperatorBakery(Bakery):
         See https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/custom-resource/reference/#resource
         for accepted keys and what they mean. Specifically, note that this is *not*
         specified the same way as kubernetes resource requests in general.
+
+        Note that at least memory *must* be set.
         """,
     )
 

--- a/pangeo_forge_runner/bakery/flink.py
+++ b/pangeo_forge_runner/bakery/flink.py
@@ -40,9 +40,12 @@ def generate_hashed_slug(slug, limit=63, hash_length=6):
     ).lower()
 
 
-class FlinkBakery(Bakery):
+class FlinkOperatorBakery(Bakery):
     """
-    Bake a Pangeo Forge recipe on a Flink cluster
+    Bake a Pangeo Forge recipe on a Flink cluster based on the Apache Flink k8s Operator
+
+    Requires a kubernetes cluster with https://github.com/apache/flink-kubernetes-operator
+    installed
     """
 
     flink_version = Unicode(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import pytest
 
 
 # Stolen from https://stackoverflow.com/a/28950776
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def local_ip():
     """
     Return IP of current machine

--- a/tests/test_flink.py
+++ b/tests/test_flink.py
@@ -54,7 +54,7 @@ def test_flink_bake(minio):
 
         # We should have some kinda 'has this completed?' check here
         # Instead, I just wait for 2min
-        time.sleep(60 * 2)
+        time.sleep(60 * 10)
         # Open the generated dataset with xarray!
         gpcp = xr.open_dataset(
             config["TargetStorage"]["root_path"],

--- a/tests/test_flink.py
+++ b/tests/test_flink.py
@@ -1,0 +1,86 @@
+import json
+import subprocess
+import tempfile
+
+import xarray as xr
+
+
+def test_flink_bake(minio):
+    fsspec_args = {
+        "key": minio["username"],
+        "secret": minio["password"],
+        "client_kwargs": {"endpoint_url": minio["endpoint"]},
+    }
+
+    config = {
+        "Bake": {
+            "prune": True,
+            "bakery_class": "pangeo_forge_runner.bakery.flink.FlinkOperatorBakery",
+        },
+        "TargetStorage": {
+            "fsspec_class": "s3fs.S3FileSystem",
+            "fsspec_args": fsspec_args,
+            "root_path": "s3://gpcp/target/",
+        },
+        "InputCacheStorage": {
+            "fsspec_class": "s3fs.S3FileSystem",
+            "fsspec_args": fsspec_args,
+            "root_path": "s3://gpcp/input-cache/",
+        },
+        "MetadataCacheStorage": {
+            "fsspec_class": "s3fs.S3FileSystem",
+            "fsspec_args": fsspec_args,
+            "root_path": "s3://gpcp/metadata-cache/",
+        },
+    }
+
+    with tempfile.NamedTemporaryFile("w", suffix=".json") as f:
+        json.dump(config, f)
+        f.flush()
+        cmd = [
+            "pangeo-forge-runner",
+            "bake",
+            "--repo",
+            "https://github.com/pangeo-forge/gpcp-feedstock.git",
+            "--ref",
+            "2cde04745189665a1f5a05c9eae2a98578de8b7f",
+            "-f",
+            f.name,
+        ]
+        proc = subprocess.run(cmd)
+
+        assert proc.returncode == 0
+
+        # Open the generated dataset with xarray!
+        gpcp = xr.open_dataset(
+            config["TargetStorage"]["root_path"],
+            backend_kwargs={"storage_options": fsspec_args},
+            engine="zarr",
+        )
+
+        assert (
+            gpcp.title
+            == "Global Precipitation Climatatology Project (GPCP) Climate Data Record (CDR), Daily V1.3"
+        )
+        # --prune prunes to two time steps by default, so we expect 2 items here
+        assert len(gpcp.precip) == 2
+        print(gpcp)
+
+        # `mc` isn't the best way, but we want to display all the files in our minio
+        with tempfile.TemporaryDirectory() as mcd:
+            cmd = [
+                "mc",
+                "--config-dir",
+                mcd,
+                "alias",
+                "set",
+                "local",
+                minio["endpoint"],
+                minio["username"],
+                minio["password"],
+            ]
+
+            subprocess.run(cmd, check=True)
+
+            cmd = ["mc", "--config-dir", mcd, "ls", "--recursive", "local"]
+            subprocess.run(cmd, check=True)

--- a/tests/test_flink.py
+++ b/tests/test_flink.py
@@ -54,7 +54,7 @@ def test_flink_bake(minio):
 
         # We should have some kinda 'has this completed?' check here
         # Instead, I just wait for 2min
-        time.sleep(60 * 5)
+        time.sleep(60 * 2)
         # Open the generated dataset with xarray!
         gpcp = xr.open_dataset(
             config["TargetStorage"]["root_path"],

--- a/tests/test_flink.py
+++ b/tests/test_flink.py
@@ -1,6 +1,7 @@
 import json
 import subprocess
 import tempfile
+import time
 
 import xarray as xr
 
@@ -51,6 +52,9 @@ def test_flink_bake(minio):
 
         assert proc.returncode == 0
 
+        # We should have some kinda 'has this completed?' check here
+        # Instead, I just wait for 2min
+        time.sleep(60 * 5)
         # Open the generated dataset with xarray!
         gpcp = xr.open_dataset(
             config["TargetStorage"]["root_path"],


### PR DESCRIPTION
This needs to:

- [x] Create a Flink cluster by setting up a CRD to a kubernetes
  cluster, as that is where the container image used for
  execution is specified
- [x] Use `kubectl port-forward` to proxy to the flink cluster,
  so we can actually talk to it
- [ ] Figure out how to cleanup the port-forward once it's done
- [x] Validate that `kubectl` is installed
- [x] Add tests

This uses https://github.com/apache/flink-kubernetes-operator,
as that is the most actively developed, community governed
operator.

Ref https://github.com/yuvipanda/pangeo-forge-runner/issues/19