### PR TITLE
compile before execing feedstock file

### DIFF
--- a/pangeo_forge_runner/feedstock.py
+++ b/pangeo_forge_runner/feedstock.py
@@ -37,7 +37,10 @@ class Feedstock:
             filename = self.feedstock_dir / f"{module}.py"
             with open(filename) as f:
                 ns = {}
-                exec(f.read(), ns)
+                # compiling makes debugging easier: https://stackoverflow.com/a/437857
+                # Without compiling first, `inspect.getsource()` will not work, and
+                # pangeo-forge-recipes uses it to hash recipes!
+                exec(compile(source=f.read(), filename=filename, mode="exec"), ns)
                 self._import_cache[module] = ns
 
         return self._import_cache[module][export]


### PR DESCRIPTION
Without this, inspect.getsource does not work.
pangeo-forge-recipes uses that to hash functions found in the recipe (https://github.com/pangeo-forge/pangeo-forge-recipes/blob/54ec73601118e28b1ec3268f0330a764ce1aa7e8/pangeo_forge_recipes/serialization.py#L22), so the whole thing falls apart.