### PR TITLE
Pin to apache_beam 2.41.0

### DIFF
--- a/pangeo_forge_runner/commands/bake.py
+++ b/pangeo_forge_runner/commands/bake.py
@@ -78,7 +78,8 @@ class Bake(BaseCommand):
     )
 
     container_image = Unicode(
-        "pangeo/forge:2022.09.21",
+        # Provides apache_beam 2.41, which we pin to in setup.py
+        "pangeo/forge:7c87e6c",
         config=True,
         help="""
         Container image to use for this job.

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,9 @@ setup(
         "ruamel.yaml",
         "pangeo-forge-recipes",
         "traitlets",
-        "apache-beam[gcp]",
+        # Matches the version of apache_beam in the default image,
+        # specified in bake.py's container_image traitlet default
+        "apache-beam[gcp]==2.41.0",
     ],
     entry_points={
         "console_scripts": ["pangeo-forge-runner=pangeo_forge_runner.cli:main"]


### PR DESCRIPTION
- Brings in https://github.com/pangeo-data/pangeo-docker-images/pull/379
- Pin version of apache_beam in setup.py too, to reduce chances of version mismatch