### PR TITLE
Bump up to apache beam 2.42.0

### DIFF
--- a/pangeo_forge_runner/commands/bake.py
+++ b/pangeo_forge_runner/commands/bake.py
@@ -78,8 +78,8 @@ class Bake(BaseCommand):
     )
 
     container_image = Unicode(
-        # Provides apache_beam 2.41, which we pin to in setup.py
-        "pangeo/forge:7c87e6c",
+        # Provides apache_beam 2.42, which we pin to in setup.py
+        "quay.io/pangeo/forge:2022.10.20",
         config=True,
         help="""
         Container image to use for this job.

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     long_description_content_type="text/markdown",
     author="Yuvi Panda",
     author_email="yuvipanda@gmail.com",
-    version="0.6.1",
+    version="0.6.2",
     packages=find_packages(),
     install_requires=[
         "jupyter-repo2docker",
@@ -19,7 +19,7 @@ setup(
         "traitlets",
         # Matches the version of apache_beam in the default image,
         # specified in bake.py's container_image traitlet default
-        "apache-beam[gcp]==2.41.0",
+        "apache-beam[gcp]==2.42.0",
     ],
     entry_points={
         "console_scripts": ["pangeo-forge-runner=pangeo_forge_runner.cli:main"]


### PR DESCRIPTION
- Was released a couple days ago!
- Switch to quay.io to workaround dockerhub pull limits.