### PR TITLE
Support adding a requirements.txt file in feedstock dir

### DIFF
--- a/pangeo_forge_runner/bakery/base.py
+++ b/pangeo_forge_runner/bakery/base.py
@@ -23,7 +23,7 @@ class Bakery(LoggingConfigurable):
     )
 
     def get_pipeline_options(
-        self, job_name: str, container_image: str
+        self, job_name: str, container_image: str, extra_options: dict
     ) -> PipelineOptions:
         """
         Return a PipelineOptions object that will configure a Pipeline to run on this Bakery
@@ -31,6 +31,7 @@ class Bakery(LoggingConfigurable):
         job_name: A unique string representing this particular run
         container_image: A docker image spec that should be used in this run,
                          if the Bakery supports using docker images
+        extra_options: Dictionary of extra options that should be passed on to PipelineOptions
 
         """
         raise NotImplementedError("Override get_pipeline_options in subclass")

--- a/pangeo_forge_runner/bakery/dataflow.py
+++ b/pangeo_forge_runner/bakery/dataflow.py
@@ -122,7 +122,7 @@ class DataflowBakery(Bakery):
         return proposal["value"]
 
     def get_pipeline_options(
-        self, job_name: str, container_image: str
+        self, job_name: str, container_image: str, extra_options: dict
     ) -> PipelineOptions:
         """
         Return PipelineOptions for use with this Bakery
@@ -151,6 +151,7 @@ class DataflowBakery(Bakery):
             # this might solve serialization issues; cf. https://beam.apache.org/blog/beam-2.36.0/
             pickle_library="cloudpickle",
             machine_type=self.machine_type,
+            **extra_options
         )
         if self.service_account_email:
             opts.update({"service_account_email": self.service_account_email})

--- a/pangeo_forge_runner/bakery/flink.py
+++ b/pangeo_forge_runner/bakery/flink.py
@@ -170,7 +170,7 @@ class FlinkOperatorBakery(Bakery):
         }
 
     def get_pipeline_options(
-        self, job_name: str, container_image: str
+        self, job_name: str, container_image: str, extra_options: dict
     ) -> PipelineOptions:
         """
         Return PipelineOptions for use with this Bakery
@@ -246,5 +246,6 @@ class FlinkOperatorBakery(Bakery):
             save_main_session=True,
             # this might solve serialization issues; cf. https://beam.apache.org/blog/beam-2.36.0/
             pickle_library="cloudpickle",
+            **extra_options,
         )
         return PipelineOptions(**opts)

--- a/pangeo_forge_runner/bakery/local.py
+++ b/pangeo_forge_runner/bakery/local.py
@@ -29,7 +29,7 @@ class LocalDirectBakery(Bakery):
     )
 
     def get_pipeline_options(
-        self, job_name: str, container_image: str
+        self, job_name: str, container_image: str, extra_options: dict
     ) -> PipelineOptions:
         """
         Return PipelineOptions for use with this Bakery
@@ -44,4 +44,5 @@ class LocalDirectBakery(Bakery):
             save_main_session=True,
             # this might solve serialization issues; cf. https://beam.apache.org/blog/beam-2.36.0/
             pickle_library="cloudpickle",
+            **extra_options
         )

--- a/pangeo_forge_runner/commands/bake.py
+++ b/pangeo_forge_runner/commands/bake.py
@@ -150,10 +150,17 @@ class Bake(BaseCommand):
                     metadata_cache_storage.get_forge_target(job_name=job_name),
                 )
 
+                # Check for a requirements.txt file and send it to beam if we have one
+                requirements_path = feedstock.feedstock_dir / "requirements.txt"
+                extra_options = {}
+                if requirements_path.exists():
+                    extra_options["requirements_file"] = str(requirements_path)
+
                 pipeline_options = bakery.get_pipeline_options(
                     job_name=job_name,
                     # FIXME: Bring this in from meta.yaml?
                     container_image=self.container_image,
+                    extra_options=extra_options,
                 )
 
                 # Set argv explicitly to empty so Apache Beam doesn't try to parse the commandline

--- a/tests/test_bakery.py
+++ b/tests/test_bakery.py
@@ -6,4 +6,4 @@ from pangeo_forge_runner.bakery.base import Bakery
 def test_unimplemented():
     b = Bakery()
     with pytest.raises(NotImplementedError):
-        b.get_pipeline_options("test", "test")
+        b.get_pipeline_options("test", "test", {})

--- a/tests/test_dataflow.py
+++ b/tests/test_dataflow.py
@@ -97,13 +97,13 @@ def test_required_params():
     dfb.temp_gcs_location = "gs://test"
 
     with pytest.raises(ValueError):
-        dfb.get_pipeline_options("test", "test")
+        dfb.get_pipeline_options("test", "test", {})
 
     dfb.project_id = "something"
     dfb.temp_gcs_location = None
 
     with pytest.raises(ValueError):
-        dfb.get_pipeline_options("test", "test")
+        dfb.get_pipeline_options("test", "test", {})
 
 
 def test_missing_gcloud(mocker):

--- a/tests/test_dataflow.py
+++ b/tests/test_dataflow.py
@@ -73,7 +73,9 @@ def test_pipelineoptions():
     dfb.use_public_ips = True
     dfb.temp_gcs_location = "gs://something"
 
-    po = dfb.get_pipeline_options("job", "some-container:some-tag")
+    po = dfb.get_pipeline_options(
+        "job", "some-container:some-tag", {"requirements_file": "/tmp/some-file"}
+    )
     opts = po.get_all_options()
     assert opts["project"] == "hello"
     assert opts["use_public_ips"]
@@ -86,6 +88,7 @@ def test_pipelineoptions():
     assert opts["sdk_container_image"] == "some-container:some-tag"
     assert opts["job_name"] == "job"
     assert opts["runner"] == "DataflowRunner"
+    assert opts["requirements_file"] == "/tmp/some-file"
 
 
 def test_required_params():

--- a/tests/test_flink.py
+++ b/tests/test_flink.py
@@ -42,9 +42,9 @@ def test_flink_bake(minio):
             "pangeo-forge-runner",
             "bake",
             "--repo",
-            "https://github.com/pangeo-forge/gpcp-feedstock.git",
+            "https://github.com/pforgetest/gpcp-from-gcs-feedstock.git",
             "--ref",
-            "2cde04745189665a1f5a05c9eae2a98578de8b7f",
+            "4f41e02512b2078c8bdb286368a1a9d878b5cec2",
             "-f",
             f.name,
         ]

--- a/tests/test_flink.py
+++ b/tests/test_flink.py
@@ -42,9 +42,9 @@ def test_flink_bake(minio):
             "pangeo-forge-runner",
             "bake",
             "--repo",
-            "https://github.com/pforgetest/gpcp-from-gcs-feedstock.git",
+            "https://github.com/pangeo-forge/gpcp-feedstock.git",
             "--ref",
-            "4f41e02512b2078c8bdb286368a1a9d878b5cec2",
+            "2cde04745189665a1f5a05c9eae2a98578de8b7f",
             "-f",
             f.name,
         ]


### PR DESCRIPTION
If a `requirements.txt` file is found in the feedstock directory (same place meta.yaml is), it'll be just passed to apache beam which will install all packages from it in *each container* before starting work