### PR TITLE
Fix for pangeo-forge-recipes 0.9.2

### DIFF
--- a/pangeo_forge_runner/commands/bake.py
+++ b/pangeo_forge_runner/commands/bake.py
@@ -140,9 +140,7 @@ class Bake(BaseCommand):
                 # Unique name for running this particular recipe.
                 if not self.job_name:
                     # FIXME: Should include the name of repo / ref as well somehow
-                    job_name = (
-                        f"{name}-{recipe.sha256}-{int(datetime.now().timestamp())}"
-                    )
+                    job_name = f"{name}-{recipe.sha256.hex()}-{int(datetime.now().timestamp())}"
                 else:
                     job_name = self.job_name
 

--- a/pangeo_forge_runner/commands/bake.py
+++ b/pangeo_forge_runner/commands/bake.py
@@ -140,7 +140,9 @@ class Bake(BaseCommand):
                 # Unique name for running this particular recipe.
                 if not self.job_name:
                     # FIXME: Should include the name of repo / ref as well somehow
-                    job_name = f"{name}-{recipe.sha256().hex()}-{int(datetime.now().timestamp())}"
+                    job_name = (
+                        f"{name}-{recipe.sha256}-{int(datetime.now().timestamp())}"
+                    )
                 else:
                     job_name = self.job_name
 

--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,12 @@ setup(
     long_description_content_type="text/markdown",
     author="Yuvi Panda",
     author_email="yuvipanda@gmail.com",
-    version="0.6.2",
+    version="0.7.0",
     packages=find_packages(),
     install_requires=[
         "jupyter-repo2docker",
         "ruamel.yaml",
-        "pangeo-forge-recipes",
+        "pangeo-forge-recipes>=0.9.2",
         "traitlets",
         # Matches the version of apache_beam in the default image,
         # specified in bake.py's container_image traitlet default


### PR DESCRIPTION
Brings in support for
ttps://github.com/pangeo-forge/pangeo-forge-recipes/pull/429, but will stop working with any prior versions