### PR TITLE
Add beam-refactor feedstock_ref to test params

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "*" ]
 
 jobs:
   build:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: ["3.9"]
         recipes-version: [
           "pangeo-forge-recipes==0.9.2",
-          "https://github.com/pangeo-forge/pangeo-forge-recipes.git@beam-refactor",
+          "git+https://github.com/pangeo-forge/pangeo-forge-recipes.git@beam-refactor",
         ]
 
     steps:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -14,6 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9"]
+        recipes-version: [
+          "pangeo-forge-recipes==0.9.2",
+          "https://github.com/pangeo-forge/pangeo-forge-recipes.git@beam-refactor",
+        ]
 
     steps:
     - uses: actions/checkout@v3
@@ -41,6 +45,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install -r dev-requirements.txt
         python -m pip install -e .
+        python -m pip install -U ${{ matrix.recipes-version }}
 
     - name: Test with pytest
       run: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,7 @@ sphinx:
   configuration: docs/conf.py
 
 python:
-  version: "3.8"
+  version: "3.9"
   install:
     # Install package too, so autodoc works
     - method: pip

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,7 @@ sphinx:
   configuration: docs/conf.py
 
 python:
+  version: "3.8"
   install:
     # Install package too, so autodoc works
     - method: pip

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,8 +3,12 @@ version: 2
 sphinx:
   configuration: docs/conf.py
 
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
 python:
-  version: "3.9"
   install:
     # Install package too, so autodoc works
     - method: pip

--- a/pangeo_forge_runner/commands/bake.py
+++ b/pangeo_forge_runner/commands/bake.py
@@ -134,7 +134,7 @@ class Bake(BaseCommand):
 
             if self.prune:
                 # Prune recipes to only run on certain items if we are asked to
-                if hasattr(list(recipes.items())[0], "copy_pruned"):
+                if hasattr(next(iter(recipes.values())), "copy_pruned"):
                     # pangeo-forge-recipes version < 0.10 has a `copy_pruned` method
                     recipes = {k: r.copy_pruned() for k, r in recipes.items()}
 

--- a/tests/test_bake.py
+++ b/tests/test_bake.py
@@ -14,9 +14,16 @@ def recipes_version_ref():
     recipes_version = [
         p.split()[-1] for p in pip_list if p.startswith("pangeo-forge-recipes")
     ][0]
-    # for now, beam-refactor is unreleased, so installing from the the dev branch does not include
-    # the branch name as part of the installed version name. therefore, we just assume with 'else'
-    return "0.9.x" if recipes_version.startswith("0.9") else "beam-refactor"
+    return (
+        "0.9.x"
+        # FIXME: for now, beam-refactor is unreleased, so installing from the dev branch
+        # gives something like "0.9.1.dev86+g6e9c341" as the version. So we just assume any
+        # version which includes "dev" is the "beam-refactor" branch, because we're not
+        # installing from any other upstream dev branch at this point. After beam-refactor
+        # release, we can figure this out based on an explicit version tag, i.e. "0.10.*".
+        if "dev" not in recipes_version
+        else "beam-refactor"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_bake.py
+++ b/tests/test_bake.py
@@ -7,19 +7,21 @@ import xarray as xr
 
 
 @pytest.mark.parametrize(
-    "recipe_id, expected_error, custom_job_name",
+    "recipe_id, expected_error, custom_job_name, feedstock_ref",
     (
-        [None, None, None],
-        ["gpcp-from-gcs", None, None],
+        [None, None, None, "0.9.x"],
+        ["gpcp-from-gcs", None, None, "0.9.x"],
         [
             "invalid_recipe_id",
             "ValueError: self.recipe_id='invalid_recipe_id' not in ['gpcp-from-gcs']",
             None,
+            "0.9.x",
         ],
-        [None, None, "special-name-for-job"],
+        [None, None, "special-name-for-job", "0.9.x"],
+        [None, None, None, "beam-refactor"],
     ),
 )
-def test_gpcp_bake(minio, recipe_id, expected_error, custom_job_name):
+def test_gpcp_bake(minio, recipe_id, expected_error, custom_job_name, feedstock_ref):
     fsspec_args = {
         "key": minio["username"],
         "secret": minio["password"],
@@ -62,7 +64,7 @@ def test_gpcp_bake(minio, recipe_id, expected_error, custom_job_name):
             "--repo",
             "https://github.com/pforgetest/gpcp-from-gcs-feedstock.git",
             "--ref",
-            "4f41e02512b2078c8bdb286368a1a9d878b5cec2",
+            feedstock_ref,
             "--json",
             "-f",
             f.name,


### PR DESCRIPTION
Parametrizes bake test with https://github.com/pforgetest/gpcp-from-gcs-feedstock/pull/4 (while also keeping a `0.9.x` ref of that feedstock for backwards compatibility testing).