### PR TITLE
Upgrade to recipes 0.9.4

### DIFF
--- a/pangeo_forge_runner/commands/bake.py
+++ b/pangeo_forge_runner/commands/bake.py
@@ -77,8 +77,8 @@ class Bake(BaseCommand):
     )
 
     container_image = Unicode(
-        # Provides apache_beam 2.42, which we pin to in setup.py
-        "quay.io/pangeo/forge:2022.10.20",
+        # Provides apache_beam 2.43, which we pin to in setup.py
+        "quay.io/pangeo/forge:8904ade",
         config=True,
         help="""
         Container image to use for this job.

--- a/setup.py
+++ b/setup.py
@@ -10,17 +10,17 @@ setup(
     long_description_content_type="text/markdown",
     author="Yuvi Panda",
     author_email="yuvipanda@gmail.com",
-    version="0.7.1",
+    version="0.7.2",
     packages=find_packages(),
     python_requires=">=3.9",
     install_requires=[
         "jupyter-repo2docker",
         "ruamel.yaml",
-        "pangeo-forge-recipes>=0.9.2",
+        "pangeo-forge-recipes>=0.9.4",
         "traitlets",
         # Matches the version of apache_beam in the default image,
         # specified in bake.py's container_image traitlet default
-        "apache-beam[gcp]==2.42.0",
+        "apache-beam[gcp]==2.43.0",
     ],
     entry_points={
         "console_scripts": ["pangeo-forge-runner=pangeo_forge_runner.cli:main"]


### PR DESCRIPTION
I've been trying to patch around this but realized upgrading this here is the only option, because the latest release of `pangeo-forge-runner` is pinned to beam `2.42.0` and we need beam `2.43.0` for compatibility with the latest `pangeo/forge` image tag.

@yuvipanda, regarding the `0.7.2` tag, in making this change I realized this repo does not actually have a `0.7.1` tag, but there is a `0.7.1` release on PyPI. Any way to retroactively tag `0.7.1` here?

_Edit_: xref https://github.com/pangeo-forge/pangeo-forge-orchestrator/pull/210