### PR TITLE
[base:`fix-df`] specify dataflow test job name

### DIFF
--- a/.github/workflows/dataflow.yaml
+++ b/.github/workflows/dataflow.yaml
@@ -10,7 +10,7 @@ on:
     - cron: '0 4 * * *' # run once a day at 4 AM
 
 jobs:
-  build:
+  test-dataflow:
     name: ${{ matrix.python-version }}
     # run on:
     #  - all pushes to main


### PR DESCRIPTION
Gives the dataflow integration test a more specific name, so that we can make a branch protection rule around it more easily.