### PR TITLE
Inject cache target too!

### DIFF
--- a/pangeo_forge_runner/commands/bake.py
+++ b/pangeo_forge_runner/commands/bake.py
@@ -164,6 +164,13 @@ class Bake(BaseCommand):
                     "target": target_storage.get_forge_target(job_name=self.job_name),
                 }
             }
+
+            cache_target = input_cache_storage.get_forge_target(job_name=self.job_name)
+            if cache_target:
+                callable_args_injections |= {
+                    "OpenURLWithFSSpec": {"cache": cache_target},
+                }
+
             feedstock = Feedstock(
                 Path(checkout_dir) / self.feedstock_subdir,
                 prune=self.prune,


### PR DESCRIPTION
Without this, no caching at all happens.

Will work on a *generic* way to inject things into things, so transforms outside the default pangeo-forge-recipes will also work.