### PR TITLE
Rename StoreToZarr kw from 'target' -> 'target_root'

### DIFF
--- a/pangeo_forge_runner/commands/bake.py
+++ b/pangeo_forge_runner/commands/bake.py
@@ -161,7 +161,9 @@ class Bake(BaseCommand):
 
             callable_args_injections = {
                 "StoreToZarr": {
-                    "target": target_storage.get_forge_target(job_name=self.job_name),
+                    "target_root": target_storage.get_forge_target(
+                        job_name=self.job_name
+                    ),
                 }
             }
 


### PR DESCRIPTION
As of https://github.com/pangeo-forge/pangeo-forge-recipes/pull/495 this kw name on StoreToZarr has changed, but it was not changed here.