### PR TITLE
Automate releases with `release.yaml`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,4 @@
-# Same as https://github.com/pangeo-forge/pangeo-forge-recipes/blob/main/.github/workflows/release.yaml
-
-name: Release Python Package
+name: Release
 
 on:
   release:
@@ -9,6 +7,10 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: release
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -19,12 +21,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade setuptools setuptools-scm wheel twine toml
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: "__token__"
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+      - name: Build
         run: |
           python setup.py sdist bdist_wheel
           python setup.py --version
           twine check dist/*
-          twine upload dist/*
+          ls -l dist
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: startsWith(github.ref, 'refs/tags/')
+  

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,8 @@
 name: Release
 
 on:
-  release:
-    types: [created]
+  push:
+    tags: ["**"]
 
 jobs:
   deploy:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,30 @@
+# Same as https://github.com/pangeo-forge/pangeo-forge-recipes/blob/main/.github/workflows/release.yaml
+
+name: Release Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools setuptools-scm wheel twine toml
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: "__token__"
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          python setup.py sdist bdist_wheel
+          python setup.py --version
+          twine check dist/*
+          twine upload dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+_version.py
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,5 +2,5 @@ autodoc-traits
 myst-parser
 pre-commit
 pydata-sphinx-theme
-sphinx>=1.7
+sphinx>=1.7,<7.2  # https://github.com/sphinx-doc/sphinx/issues/11631
 sphinx-copybutton

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,14 @@
+[build-system]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
+
+[project]
+name = "pangeo-forge-runner"
+dynamic = ["version"]
+
+[tool.setuptools_scm]
+write_to = "pangeo_forge_runner/_version.py"
+write_to_template = "__version__ = '{version}'"
+
 [tool.isort]
 # Prevent isort & black from fighting each otherd
 profile = "black"

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,11 @@ with open("README.md") as f:
     readme = f.read()
 
 setup(
-    name="pangeo-forge-runner",
     description="Commandline tool to manage pangeo-forge feedstocks",
     long_description=readme,
     long_description_content_type="text/markdown",
     author="Yuvi Panda",
     author_email="yuvipanda@gmail.com",
-    version="0.7.2",
     packages=find_packages(),
     python_requires=">=3.9",
     install_requires=[


### PR DESCRIPTION
Currently:

- latest release according to pypi is `0.7.1`
- latest tag on GitHub is `v0.7.0`
- latest release according to GitHub releases page is `0.6.1`

🙃 

This PR adds the same `release.yaml` as used in `pangeo-forge-recipes` to automate this process.

@yuvipanda, if this looks good to you, I can add a pypi token as a repo secret and cut a `0.8.0` release.