### PR TITLE
Fix local flink test

### DIFF
--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Setup FlinkOperator
       run: |
-        FLINK_OPERATOR_VERSION=1.3.0
+        FLINK_OPERATOR_VERSION=1.5.0
         helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-${FLINK_OPERATOR_VERSION}
         helm install flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator --wait
 

--- a/tests/integration/test_flink.py
+++ b/tests/integration/test_flink.py
@@ -50,10 +50,7 @@ def test_flink_bake(minio):
         ]
         proc = subprocess.run(cmd, capture_output=True)
 
-        if proc.returncode != 0:
-            print(proc.stderr.decode())
-
-        assert proc.returncode == 0  # bail if proc did not succeed
+        assert proc.returncode == 0
 
         # We should have some kinda 'has this completed?' check here
         # Instead, I just wait for 3min

--- a/tests/integration/test_flink.py
+++ b/tests/integration/test_flink.py
@@ -42,7 +42,7 @@ def test_flink_bake(minio):
             "pangeo-forge-runner",
             "bake",
             "--repo",
-            "https://github.com/pangeo-forge/gpcp-feedstock.git",
+            "https://github.com/pforgetest/gpcp-from-gcs-feedstock.git",
             "--ref",
             "beam-refactor",
             "-f",

--- a/tests/integration/test_flink.py
+++ b/tests/integration/test_flink.py
@@ -48,9 +48,12 @@ def test_flink_bake(minio):
             "-f",
             f.name,
         ]
-        proc = subprocess.run(cmd)
+        proc = subprocess.run(cmd, capture_output=True)
 
-        assert proc.returncode == 0
+        if proc.returncode != 0:
+            print(proc.stderr.decode())
+
+        assert proc.returncode == 0  # bail if proc did not succeed
 
         # We should have some kinda 'has this completed?' check here
         # Instead, I just wait for 3min

--- a/tests/integration/test_flink.py
+++ b/tests/integration/test_flink.py
@@ -44,7 +44,7 @@ def test_flink_bake(minio):
             "--repo",
             "https://github.com/pangeo-forge/gpcp-feedstock.git",
             "--ref",
-            "2cde04745189665a1f5a05c9eae2a98578de8b7f",
+            "beam-refactor",
             "-f",
             f.name,
         ]


### PR DESCRIPTION
Looks like the local Flink test was failing due to an unavailable Flink operator version.

The terraform for the AWS cloud deployment uses version `1.5.0`, so starting by upgrading to that here.