### PR TITLE
Cleanup how we pick beam or no-beam versions of recipes to test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,18 +57,3 @@ def minio(local_ip):
         proc.wait()
 
         assert proc.returncode == 0
-
-
-@pytest.fixture
-def recipes_version_ref():
-    # FIXME: recipes version matrix is currently determined by github workflows matrix
-    # in the future, it should be set by pangeo-forge-runner venv feature?
-    pip_list = subprocess.check_output("pip list".split()).decode("utf-8").splitlines()
-    recipes_version = [
-        p.split()[-1] for p in pip_list if p.startswith("pangeo-forge-recipes")
-    ][0]
-    # the recipes_version is a 3-element semantic version of form `0.A.B` where A is either minor
-    # version `9` or `10`. the test feedstock (pforgetest/gpcp-from-gcs-feedstock) has tags for
-    # each of these minor versions, of the format `0.A.x`, so we translate the installed version
-    # of pangeo-forge-recipes to one of the valid tags (either `0.9.x` or `0.10.x`) here.
-    return f"0.{recipes_version.split('.')[1]}.x"

--- a/tests/integration/test_dataflow_integration.py
+++ b/tests/integration/test_dataflow_integration.py
@@ -2,12 +2,19 @@ import json
 import subprocess
 import tempfile
 import time
+from importlib.metadata import version
 
 import pytest
 import xarray as xr
+from packaging.version import parse as parse_version
 
 
-def test_dataflow_integration(recipes_version_ref):
+def test_dataflow_integration():
+    pfr_version = parse_version(version("pangeo-forge-recipes"))
+    if pfr_version >= parse_version("0.10"):
+        recipe_version_ref = "0.10.x"
+    else:
+        recipe_version_ref = "0.9.x"
     bucket = "gs://pangeo-forge-runner-ci-testing"
     config = {
         "Bake": {
@@ -40,7 +47,7 @@ def test_dataflow_integration(recipes_version_ref):
             "--ref",
             # in the test feedstock, tags are named for the recipes version
             # which was used to write the recipe module
-            recipes_version_ref,
+            recipe_version_ref,
             "--json",
             "-f",
             f.name,
@@ -93,8 +100,8 @@ def test_dataflow_integration(recipes_version_ref):
 
         # open the generated dataset with xarray!
         target_path = config["TargetStorage"]["root_path"].format(job_name=job_name)
-        if recipes_version_ref == "0.10.x":
-            # in pangeo-forge-recipes>=0.10.0, an additional `StoreToZarr.store_name` kwarg
+        if pfr_version >= parse_version("0.10"):
+            # in pangeo-forge-eecipes>=0.10.0, an additional `StoreToZarr.store_name` kwarg
             # is appended to the formatted root path at execution time. for ref `0.10.x`,
             # the value of that kwarg is "gpcp", so we append that here.
             target_path += "/gpcp"


### PR DESCRIPTION
- Explicitly find the version we care about in a way that works for local installs too - current code doesn't clearly parse output of local .dev installs of pangeo-forge-recipes.
- The fixture made it appear to be a general pattern in use across repos - but this tagging ref is actually only true for a specific repo. So move the parsing code close to where it is used, rather than in a more general place.