### PR TITLE
Support arbitrary python & beam versions, stop using pangeo/forge image

### DIFF
--- a/.github/workflows/dataflow.yaml
+++ b/.github/workflows/dataflow.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.9", "3.10", "3.11"]
         recipes-version: [
           "pangeo-forge-recipes==0.9.4",
           "pangeo-forge-recipes==0.10.0",

--- a/.github/workflows/dataflow.yaml
+++ b/.github/workflows/dataflow.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9"]
         recipes-version: [
           "pangeo-forge-recipes==0.9.4",
           "pangeo-forge-recipes==0.10.0",

--- a/.github/workflows/dataflow.yaml
+++ b/.github/workflows/dataflow.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
         recipes-version: [
           "pangeo-forge-recipes==0.9.4",
           "pangeo-forge-recipes==0.10.0",

--- a/.github/workflows/dataflow.yaml
+++ b/.github/workflows/dataflow.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
         recipes-version: [
           "pangeo-forge-recipes==0.9.4",
           "pangeo-forge-recipes==0.10.0",

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9"]
         recipes-version: [
           "pangeo-forge-recipes==0.9.4",
           "pangeo-forge-recipes==0.10.0",

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
         recipes-version: [
           "pangeo-forge-recipes==0.9.4",
           "pangeo-forge-recipes==0.10.0",

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.9", "3.10", "3.11"]
         recipes-version: [
           "pangeo-forge-recipes==0.9.4",
           "pangeo-forge-recipes==0.10.0",

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
         recipes-version: [
           "pangeo-forge-recipes==0.9.4",
           "pangeo-forge-recipes==0.10.0",

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include pangeo_forge_runner/commands/pangeo-forge-recipes-0.9-requirements.txt

--- a/pangeo_forge_runner/bakery/flink.py
+++ b/pangeo_forge_runner/bakery/flink.py
@@ -129,24 +129,24 @@ class FlinkOperatorBakery(Bakery):
     )
 
     parallelism = Integer(
-        None,
-        allow_none=True,
+        -1,
         config=True,
         help="""
         The degree of parallelism to be used when distributing operations onto workers.
-        If the parallelism is not set, the configured Flink default is used,
-        or 1 if none can be found.
+
+        Defaults to -1, which uses Flinks' defaults.
         """,
     )
 
     max_parallelism = Integer(
-        None,
-        allow_none=True,
+        -1,
         config=True,
         help="""
         The pipeline wide maximum degree of parallelism to be used.
         The maximum parallelism specifies the upper limit for dynamic scaling
         and the number of key groups used for partitioned state.
+
+        Defaults to -1, which is no limit.
         """,
     )
 
@@ -258,13 +258,6 @@ class FlinkOperatorBakery(Bakery):
 
         print(f"You can run '{' '.join(cmd)}' to make the Flink Dashboard available!")
 
-        for k, v in dict(
-            parallelism=self.parallelism,
-            max_parallelism=self.max_parallelism,
-        ).items():
-            if v:  # if None, don't pass these options to Flink
-                extra_options |= {k: v}
-
         # Set flags explicitly to empty so Apache Beam doesn't try to parse the commandline
         # for pipeline options - we have traitlets doing that for us.
         opts = dict(
@@ -279,6 +272,8 @@ class FlinkOperatorBakery(Bakery):
             save_main_session=True,
             # this might solve serialization issues; cf. https://beam.apache.org/blog/beam-2.36.0/
             pickle_library="cloudpickle",
+            parallelism=self.parallelism,
+            max_parallelism=self.max_parallelism,
             **extra_options,
         )
         return PipelineOptions(**opts)

--- a/pangeo_forge_runner/commands/bake.py
+++ b/pangeo_forge_runner/commands/bake.py
@@ -18,6 +18,10 @@ from ..storage import InputCacheStorage, MetadataCacheStorage, TargetStorage
 from ..stream_capture import redirect_stderr, redirect_stdout
 from .base import BaseCommand, common_aliases, common_flags
 
+PFR_0_9_REQUIREMENTS_FILE_PATH = (
+    Path(__file__).parent / "pangeo-forge-recipes-0.9-requirements.txt"
+)
+
 
 class Bake(BaseCommand):
     """
@@ -216,13 +220,20 @@ class Bake(BaseCommand):
 
             bakery: Bakery = self.bakery_class(parent=self)
 
-            # Check for a requirements.txt file and send it to beam if we have one
-            requirements_path = feedstock.feedstock_dir / "requirements.txt"
             extra_options = {}
-            if requirements_path.exists():
-                extra_options["requirements_file"] = str(requirements_path)
 
             for name, recipe in recipes.items():
+                # if pangeo-forge-recipes is <=0.9, we have to specify a requirements.txt
+                # file even if it isn't present, as the image used otherwise will not have pangeo-forge-recipes
+                if isinstance(recipe, PTransform):
+                    requirements_path = feedstock.feedstock_dir / "requirements.txt"
+                    if requirements_path.exists():
+                        extra_options["requirements_file"] = str(requirements_path)
+                else:
+                    extra_options["requirements_file"] = str(
+                        PFR_0_9_REQUIREMENTS_FILE_PATH
+                    )
+
                 pipeline_options = bakery.get_pipeline_options(
                     job_name=self.job_name,
                     # FIXME: Bring this in from meta.yaml?

--- a/pangeo_forge_runner/commands/bake.py
+++ b/pangeo_forge_runner/commands/bake.py
@@ -98,11 +98,13 @@ class Bake(BaseCommand):
         return proposal.value
 
     container_image = Unicode(
-        # Provides apache_beam 2.48, which we pin to in setup.py
-        "quay.io/pangeo/forge:554675c",
+        "",
         config=True,
         help="""
         Container image to use for this job.
+
+        Defaults to letting beam automatically figure out the image to use,
+        based on version of beam and python in use.
 
         Should be accessible to whatever Beam runner is being used.
 

--- a/pangeo_forge_runner/commands/bake.py
+++ b/pangeo_forge_runner/commands/bake.py
@@ -98,8 +98,8 @@ class Bake(BaseCommand):
         return proposal.value
 
     container_image = Unicode(
-        # Provides apache_beam 2.42, which we pin to in setup.py
-        "quay.io/pangeo/forge:5e51a29",
+        # Provides apache_beam 2.48, which we pin to in setup.py
+        "quay.io/pangeo/forge:554675c",
         config=True,
         help="""
         Container image to use for this job.

--- a/pangeo_forge_runner/commands/pangeo-forge-recipes-0.9-requirements.txt
+++ b/pangeo_forge_runner/commands/pangeo-forge-recipes-0.9-requirements.txt
@@ -1,0 +1,5 @@
+# List of packages installed in the container image when
+# baking a recipe that's using pangeo-forge-recipes<0.10
+gcsfs
+pangeo-forge-recipes<0.10
+s3fs

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,7 @@ setup(
         "pangeo-forge-recipes>=0.9.2",
         "escapism",
         "traitlets",
-        # Matches the version of apache_beam in the default image,
-        # specified in bake.py's container_image traitlet default
-        "apache-beam[gcp]==2.42.0",
+        "apache-beam[gcp]",
     ],
     entry_points={
         "console_scripts": ["pangeo-forge-runner=pangeo_forge_runner.cli:main"]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         "pangeo-forge-recipes>=0.9.2",
         "escapism",
         "traitlets",
-        "apache-beam[gcp]",
+        "apache-beam[gcp]==2.48.0",
     ],
     entry_points={
         "console_scripts": ["pangeo-forge-runner=pangeo_forge_runner.cli:main"]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         "pangeo-forge-recipes>=0.9.2",
         "escapism",
         "traitlets",
-        "apache-beam[gcp]==2.48.0",
+        "apache-beam[gcp]",
     ],
     entry_points={
         "console_scripts": ["pangeo-forge-runner=pangeo_forge_runner.cli:main"]

--- a/tests/integration/test_dataflow_integration.py
+++ b/tests/integration/test_dataflow_integration.py
@@ -12,7 +12,7 @@ from packaging.version import parse as parse_version
 def test_dataflow_integration():
     pfr_version = parse_version(version("pangeo-forge-recipes"))
     if pfr_version >= parse_version("0.10"):
-        recipe_version_ref = "0.10.x"
+        recipe_version_ref = "beam-bump"
     else:
         recipe_version_ref = "0.9.x"
     bucket = "gs://pangeo-forge-runner-ci-testing"

--- a/tests/unit/test_flink.py
+++ b/tests/unit/test_flink.py
@@ -28,8 +28,6 @@ def test_pipelineoptions(
         # flink in an actual deployment, though.
         opts = po.get_all_options(retain_unknown_options=True)
 
-    assert opts["flink_version"] == "1.15"
-
     for optional_arg, value in dict(
         parallelism=parallelism,
         max_parallelism=max_parallelism,

--- a/tests/unit/test_flink.py
+++ b/tests/unit/test_flink.py
@@ -1,22 +1,15 @@
-from typing import Optional
 from unittest.mock import patch
-
-import pytest
 
 from pangeo_forge_runner.bakery.flink import FlinkOperatorBakery
 
 
-@pytest.mark.parametrize("parallelism, max_parallelism", [(None, None), (100, 100)])
-def test_pipelineoptions(
-    parallelism: Optional[int],
-    max_parallelism: Optional[int],
-):
+def test_pipelineoptions():
     """
     Quickly validate some of the PipelineOptions set
     """
     fob = FlinkOperatorBakery()
-    fob.parallelism = parallelism
-    fob.max_parallelism = max_parallelism
+    fob.parallelism = 100
+    fob.max_parallelism = 100
 
     # FlinkOperatorBakery.get_pipeline_options calls `kubectl` in a subprocess,
     # so we patch subprocess here to skip that behavior for this test
@@ -28,13 +21,5 @@ def test_pipelineoptions(
         # flink in an actual deployment, though.
         opts = po.get_all_options(retain_unknown_options=True)
 
-    for optional_arg, value in dict(
-        parallelism=parallelism,
-        max_parallelism=max_parallelism,
-    ).items():
-        # if these args are not passed, we don't want them to appear in
-        # the pipeline opts, so we verify here that is actually happening.
-        if value is None:
-            assert optional_arg not in opts
-        else:
-            assert opts[optional_arg] == value
+    assert opts["parallelism"] == 100
+    assert opts["max_parallelism"] == 100


### PR DESCRIPTION
This PR started out as a way to unpin ourselves from ancient apache beam version
(2.42) and move to something newer. However, I eventually ran into the following error https://github.com/pangeo-forge/pangeo-forge-runner/pull/90#issuecomment-1685129640 that is primarily caused by the fact that we are using a heavy base image (https://github.com/pangeo-data/pangeo-docker-images/tree/master/forge) on top of which beam installs some custom packages with requirements.txt. This leads to hard to debug errors like [this](https://github.com/pangeo-forge/pangeo-forge-runner/pull/90#issuecomment-1685129640), and life is *far* too short to deal with python dependency problems.

So instead, we finally pull the plug (as we have discussed many times) on using the pangeo/forge image completely, and now start requiring that all dependencies be listed explicitly in `requirements.txt`. Beam automatically determines the image to use based on both the version of python as well as beam, picking one of [the images the beam community maintains](https://hub.docker.com/search?q=apache%2Fbeam&type=image). These are also *far smaller* than the pangeo forge image, and everything is cleaner.

The complicated weird *geopandas* error I was running into in the pangeo/forge image is completely gone here!

We also add tests to run on 3 versions of python (3.9, 3.10 and 3.11), and
they all pass, including on dataflow!

In addition, this undos my suggestions about setting parallelism=None in https://github.com/pangeo-forge/pangeo-forge-runner/pull/82#discussion_r1283801480,
and use @cisaacstern's original idea for passing -1. That's what newer versions of
beam do anyway.

TODO:

- [ ] What to do for recipes versions < 0.10?