### PR TITLE
Run flink test on label

### DIFF
--- a/.github/workflows/dataflow.yaml
+++ b/.github/workflows/dataflow.yaml
@@ -14,12 +14,14 @@ jobs:
     # run on:
     #  - all pushes to main
     #  - schedule defined above
-    #  - a PR was just labeled 'test-dataflow'
-    #  - a PR with 'test-dataflow' label was opened, reopened, or synchronized
+    #  - a PR was just labeled 'test-dataflow' or 'test-all'
+    #  - a PR with 'test-dataflow' or 'test-all' label was opened, reopened, or synchronized
     if: |
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
+      github.event.label.name == 'test-all' ||
       github.event.label.name == 'test-dataflow' ||
+      contains( github.event.pull_request.labels.*.name, 'test-all') ||
       contains( github.event.pull_request.labels.*.name, 'test-dataflow')
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -5,9 +5,24 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    types: [ opened, reopened, synchronize, labeled ]
+  schedule:
+    - cron: '0 4 * * *' # run once a day at 4 AM
 
 jobs:
   build:
+    # run on:
+    #  - all pushes to main
+    #  - schedule defined above
+    #  - a PR was just labeled 'test-flink' or 'test-all'
+    #  - a PR with 'test-flink' or 'test-all' label was opened, reopened, or synchronized
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      github.event.label.name == 'test-all' ||
+      github.event.label.name == 'test-flink' ||
+      contains( github.event.pull_request.labels.*.name, 'test-all') ||
+      contains( github.event.pull_request.labels.*.name, 'test-flink')
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
We already run dataflow tests on a label.

Flink is also an integration test so it makes sense to do the same.

This PR makes the trigger for the Flink test either a `test-flink` label or a `test-all` label present on the PR, and it also adds `test-all` as a trigger for the dataflow test.

Doing this because Flink integration test failures on PRs that don't have to do with Flink are harshing the vibe 😄 .