### PR TITLE
Traitlet injection fails with chained functions (e.g. beam resource hints)

### DIFF
--- a/tests/rewriter-tests/callable-args-injection-chained/original.py
+++ b/tests/rewriter-tests/callable-args-injection-chained/original.py
@@ -1,0 +1,5 @@
+def some_callable(some_argument):
+    pass
+
+
+some_callable().some_func()

--- a/tests/rewriter-tests/callable-args-injection-chained/params.py
+++ b/tests/rewriter-tests/callable-args-injection-chained/params.py
@@ -1,0 +1,4 @@
+# Parameters to be passed to RecipeRewriter constructor
+params = dict(
+    prune=False, callable_args_injections={"some_callable": {"some_argument": 42}}
+)

--- a/tests/rewriter-tests/callable-args-injection-chained/rewritten.py
+++ b/tests/rewriter-tests/callable-args-injection-chained/rewritten.py
@@ -1,0 +1,9 @@
+def some_callable(some_argument):
+    pass
+
+
+some_callable(
+    some_argument=_CALLABLE_ARGS_INJECTIONS.get("some_callable", {}).get(  # noqa
+        "some_argument"
+    )
+).some_func()


### PR DESCRIPTION
@cisaacstern and I just went on a bit of a deep dive to debug failures ([example](https://github.com/leap-stc/cmip6-leap-feedstock/actions/runs/6085623589)) over at [cmip6-leap-feedstock](https://github.com/leap-stc/cmip6-leap-feedstock), and discovered that the traitlet injection was failing for stages with resource hints like this:

```python
...
StoreToZarr(....).with_resource_hints(min_ram=min_ram)
...
```

This PR adds a minimal failing example for the `test_rewriter.py` module.