### PR TITLE
Add DaskBakery

### DIFF
--- a/pangeo_forge_runner/bakery/dask.py
+++ b/pangeo_forge_runner/bakery/dask.py
@@ -1,0 +1,82 @@
+"""
+Bakery for baking pangeo-forge recipes with DaskRunner
+"""
+from apache_beam.pipeline import PipelineOptions
+from traitlets import Dict, Unicode
+
+from .base import Bakery
+
+
+class DaskBakery(Bakery):
+    """
+    Bake recipes on any Dask cluster.
+
+    Uses the Apache Beam DaskRunner.
+    """
+
+    client_address = Unicode(
+        None,
+        allow_none=True,
+        config=True,
+        help="""
+        Address of the Dask client.
+        If none, a ``LocalCluster`` is created just for this run.
+        """,
+    )
+
+    client_kwargs = Dict(
+        {},
+        config=True,
+        help="""
+        """,
+    )
+
+    local_cluster_kwargs = Dict(
+        {},
+        config=True,
+        help="""
+        """,
+    )
+
+    def get_pipeline_options(
+        self, job_name: str, container_image: str, extra_options: dict
+    ) -> PipelineOptions:
+        """
+        Return PipelineOptions for use with this Bakery
+        """
+        try:
+            # TODO: string registration of "DaskRunner" doesn't appear to work?
+            from apache_beam.runners.dask.dask_runner import DaskRunner
+        except ImportError as e:
+            raise ValueError(
+                "Unable to import ``apache_beam.runners.dask.dask_runner.DaskRunner``, "
+                "please upgrade to apache-beam>=2.43.0."
+            ) from e
+
+        client = None
+        if not self.client_address:
+            self.log.info("...")
+            import dask.distributed as distributed
+
+            cluster = distributed.LocalCluster(**self.local_cluster_kwargs)
+            self.client_kwargs |= {"cluster": cluster}
+            client = distributed.Client(**self.client_kwargs)
+            self.client_address = client.scheduler.address
+
+        if client:
+            self.log.info(f"Dask dashboard is available at: {client.dashboard_link}")
+        else:
+            # TODO: can we get a dashboard link deterministically from an
+            # explicitly-passed client_address? If so, let's log it here
+            pass
+
+        # Set flags explicitly to empty so Apache Beam doesn't try to parse the commandline
+        # for pipeline options - we have traitlets doing that for us.
+        return PipelineOptions(
+            flags=[],
+            runner=DaskRunner(),
+            dask_client_address=self.client_address,
+            save_main_session=True,
+            pickle_library="cloudpickle",
+            **extra_options,
+        )


### PR DESCRIPTION
Thanks to @alxmrs's [heroic efforts](https://github.com/apache/beam/pull/22421), Beam has a DaskRunner. This PR adds that runner as a configurable option here.

This should be a broadly useful deployment target, and was specifically motivated by our struggles in https://github.com/pangeo-forge/pangeo-forge-recipes/issues/618 to establish the usefulness of the LocalDirectRunner's usefulness for single-machine parallelization. Pangeo Forge users with this use case can leverage Dask's LocalCluster for this purpose going forward.

I've so far been able to confirm the scaling functionality of the DaskRunner + LocalCluster with the following example (h/t @TomNicholas for help with this):


```python
# dask_runner_test.py

import time

import apache_beam as beam
from apache_beam.pipeline import PipelineOptions
from apache_beam.runners.dask.dask_runner import DaskRunner
from dask.distributed import LocalCluster
from dask.distributed import Client

def sleep(x):
    time.sleep(2)
    return

input_data = list(range(1, 30))
worker_counts = [1, 2, 4, 8, 16]

if __name__ == "__main__":
    for n_workers in worker_counts:
        print(f"Mapping function 'sleep' across {n_workers = }")
        
        cluster = LocalCluster(n_workers=n_workers, threads_per_worker=1)
        client = Client(cluster)
        client.wait_for_workers(n_workers)
        options = [f"--dask_client_address={client.scheduler.address}"]

        start_time = time.time()
        with beam.Pipeline(runner=DaskRunner(), options=PipelineOptions(options)) as p:
            result = (
                p
                | "CreateInput" >> beam.Create(input_data)
                | "Map" >> beam.Map(sleep)
            )

        end_time = time.time()
        elapsed_time = end_time - start_time
        print(f"Elapsed time with {n_workers = }: {elapsed_time} seconds")
```
```console
➜ python dask_runner_test.py
Mapping function 'sleep' across n_workers = 1
Elapsed time with n_workers = 1: 58.47139596939087 seconds
Mapping function 'sleep' across n_workers = 2
Elapsed time with n_workers = 2: 30.290652751922607 seconds
Mapping function 'sleep' across n_workers = 4
Elapsed time with n_workers = 4: 16.250579833984375 seconds
Mapping function 'sleep' across n_workers = 8
Elapsed time with n_workers = 8: 8.254508972167969 seconds
Mapping function 'sleep' across n_workers = 16
Elapsed time with n_workers = 16: 4.343317985534668 seconds
```