### PR TITLE
Bump gcsfs version in dataflow test

### DIFF
--- a/.github/workflows/dataflow.yaml
+++ b/.github/workflows/dataflow.yaml
@@ -55,7 +55,7 @@ jobs:
     # FIXME: should gcsfs actually be part of some optional installs in setup.py?
     - name: Install gcsfs
       run: |
-        python -m pip install 'gcsfs==2022.8.2'
+        python -m pip install 'gcsfs>=2023.4.0'
 
     - name: 'Run Dataflow Integration Test'
       run: |


### PR DESCRIPTION
This version pin is what's causing the integration test failures in #90, I'm pretty sure!