### PR TITLE
Use explicit version ref for >=0.10 integration tests

### DIFF
--- a/tests/integration/test_dataflow_integration.py
+++ b/tests/integration/test_dataflow_integration.py
@@ -12,7 +12,7 @@ from packaging.version import parse as parse_version
 def test_dataflow_integration():
     pfr_version = parse_version(version("pangeo-forge-recipes"))
     if pfr_version >= parse_version("0.10"):
-        recipe_version_ref = "beam-bump"
+        recipe_version_ref = str(pfr_version)
     else:
         recipe_version_ref = "0.9.x"
     bucket = "gs://pangeo-forge-runner-ci-testing"


### PR DESCRIPTION
Previously, we were using a single version of the `pforgetest/gpcp-from-gcs-feedstock` for testing all versions of recipe >= 0.10. This PR makes that version ref explicit. I've made appropriately named tags on `pforgetest/gpcp-from-gcs-feedstock` to correspond to the matrix of recipe versions we use in our tests here.