### PR TITLE
WIP: Flink: add os env var secrets flow

### DIFF
--- a/pangeo_forge_runner/bakery/flink.py
+++ b/pangeo_forge_runner/bakery/flink.py
@@ -175,9 +175,7 @@ class FlinkOperatorBakery(Bakery):
         return {
             "apiVersion": "v1",
             "kind": "Secret",
-            "metadata": {
-                "name": secret_name
-            },
+            "metadata": {"name": secret_name},
             "type": "Opague",
             "stringData": secret_key_values,
         }
@@ -219,14 +217,8 @@ class FlinkOperatorBakery(Bakery):
                                 },
                                 {
                                     "name": "flink-main-container",
-                                    "envFrom": [
-                                        {
-                                            "secretRef": {
-                                                "name": secret_name
-                                            }
-                                        }
-                                    ],
-                                }
+                                    "envFrom": [{"secretRef": {"name": secret_name}}],
+                                },
                             ]
                         }
                     },
@@ -256,9 +248,7 @@ class FlinkOperatorBakery(Bakery):
 
         # Create the secret in the k8s cluster
         with tempfile.NamedTemporaryFile(mode="w") as f:
-            f.write(
-                json.dumps(self.make_k8s_secret(secret_name))
-            )
+            f.write(json.dumps(self.make_k8s_secret(secret_name)))
             f.flush()
             cmd = ["kubectl", "apply", "--wait", "-f", f.name]
             subprocess.check_call(cmd)
@@ -314,7 +304,9 @@ class FlinkOperatorBakery(Bakery):
         # Use rsplit in case we listen on ipv6 stuff in the future
         listen_port = listen_address.rsplit(":", 1)[1]
 
-        self.log.info(f"You can run '{' '.join(cmd)}' to make the Flink Dashboard available!")
+        self.log.info(
+            f"You can run '{' '.join(cmd)}' to make the Flink Dashboard available!"
+        )
 
         # Set flags explicitly to empty so Apache Beam doesn't try to parse the commandline
         # for pipeline options - we have traitlets doing that for us.


### PR DESCRIPTION
This actually brings up some interesting trade-offs:

1. allowing users to pass secrets from pforge runner to `kubectl` for secrets:
     * *benefit*: normal workflow but it's probably not the best practice in terms of security even though the traffic between the `kubectl` client and cluster is encrypted
     * *drawback*: There are still vectors of attack and just dumb things that can happen such as committing your config by accident

2. It's already given our config will usually have cloud provider credentials for an IAM user/role(s) with certain EKS permissions (which are still subject to the first point above). Maybe the best practice is for recipes to leverage the cloud providers secret managers and pick up secrets that way?
     * *benefit*: management is delegated back to the user
     * *drawback*: worker pods would need to use IRSA so we'd have to plumb that stuff through via either SA and annotations or OIDC flows
     * *drawback*: There are still vectors of attack and just dumb things that can happen such as committing your config by accident
     * *drawback*: If recipes are delegating secret management to each cloud-provider SM resource then recipes are not agnostic anymore
