### PR TITLE
Add GitHub icon link to docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,3 +30,13 @@ source_suffix = [".rst", ".md"]
 
 html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
+
+html_theme_options = {
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/pangeo-forge/pangeo-forge-runner",
+            "icon": "fa-brands fa-github",
+        },
+    ],
+}


### PR DESCRIPTION
I'm always looking for this when I'm on the docs page 😆 

So finally adding it