### PR TITLE
In meta_yaml recipes section, `dict_object`s should be a list element

### DIFF
--- a/pangeo_forge_runner/feedstock.py
+++ b/pangeo_forge_runner/feedstock.py
@@ -76,13 +76,16 @@ class Feedstock:
         *Executes arbitrary code* defined in the feedstock recipes.
         """
         recipes = {}
-        if isinstance(self.meta.recipes, list):
-            for r in self.meta.recipes:
+        for r in self.meta.recipes:
+            if {"id", "object"} == set(r.keys()):
                 recipes[r["id"]] = self._import(r["object"])
-        elif isinstance(self.meta.recipes, dict):
-            recipes = self._import(self.meta.recipes["dict_object"])
-        else:
-            raise ValueError("Could not parse recipes config in meta.yaml")
+            elif {"dict_object"} == set(r.keys()):
+                dict_object = self._import(r["dict_object"])
+                for k, v in dict_object.items():
+                    recipes[k] = v
+            else:
+                # MetaYaml schema validation should prevent us from ever hitting this.
+                raise ValueError("Could not parse recipes config in meta.yaml")
 
         return recipes
 
@@ -94,18 +97,26 @@ class Feedstock:
         'object' keys *may* be present, but not guaranteed.
         """
         meta_copy = deepcopy(self.meta)
-        if self.meta.recipes and "dict_object" in self.meta.recipes:
-            # We have a dict_object, so let's parse the recipes, and provide
-            # keep just the ids, discarding the values - as the values do not
-            # actually serialize.
-            recipes = self.parse_recipes()
-            meta_copy.recipes = [
-                # In place of the values, we add a placeholder string, so that the
-                # re-assignment to the MetaYaml schema here will pass validation
-                # of the `recipes` field, which requires "id" and "object" fields.
-                {"id": k, "object": "DICT_VALUE_PLACEHOLDER"}
-                for k, _ in recipes.items()
+        for i, r in enumerate(self.meta.recipes):
+            if "dict_object" in r:
+                # We have a dict_object, so let's parse the recipes, and provide
+                # keep just the ids, discarding the values - as the values do not
+                # actually serialize.
+                recipes = self.parse_recipes()
+                meta_copy.recipes[i] = [
+                    # In place of the values, we add a placeholder string, so that the
+                    # re-assignment to the MetaYaml schema here will pass validation
+                    # of the `recipes` field, which requires "id" and "object" fields.
+                    {"id": k, "object": "DICT_VALUE_PLACEHOLDER"}
+                    for k, _ in recipes.items()
+                ]
+        if any([isinstance(r, list) for r in meta_copy.recipes]):
+            # if we expanded any dict_objects above, then we'll have some nested lists
+            # which we need to flatten here before moving on
+            all_aslists = [
+                (r if isinstance(r, list) else [r]) for r in meta_copy.recipes
             ]
+            meta_copy.recipes = sum(all_aslists, [])
 
         return (
             # the traitlets MetaYaml schema will give us empty containers

--- a/pangeo_forge_runner/feedstock.py
+++ b/pangeo_forge_runner/feedstock.py
@@ -77,15 +77,21 @@ class Feedstock:
         """
         recipes = {}
         for r in self.meta.recipes:
+            assert any(
+                # MetaYaml schema validation of self.meta ensures that one of these two
+                # conditions is true, but just assert anyway, to make sure there are no
+                # edge cases that slip through the cracks.
+                [
+                    key_set == set(r.keys())
+                    for key_set in ({"id", "object"}, {"dict_object"})
+                ]
+            )
             if {"id", "object"} == set(r.keys()):
                 recipes[r["id"]] = self._import(r["object"])
             elif {"dict_object"} == set(r.keys()):
                 dict_object = self._import(r["dict_object"])
                 for k, v in dict_object.items():
                     recipes[k] = v
-            else:
-                # MetaYaml schema validation should prevent us from ever hitting this.
-                raise ValueError("Could not parse recipes config in meta.yaml")
 
         return recipes
 

--- a/pangeo_forge_runner/meta_yaml.py
+++ b/pangeo_forge_runner/meta_yaml.py
@@ -1,13 +1,17 @@
 import jsonschema
-from traitlets import Dict, HasTraits, List, TraitError, Unicode, Union, validate
+from traitlets import Dict, HasTraits, List, TraitError, Unicode, validate
 
 recipes_field_per_element_schema = {
     "type": "object",
     "properties": {
         "id": {"type": "string"},
         "object": {"type": "string"},
+        "dict_object": {"type": "string"},
     },
-    "required": ["id", "object"],
+    "oneOf": [
+        {"required": ["id", "object"]},
+        {"required": ["dict_object"]},
+    ],
 }
 
 
@@ -55,8 +59,8 @@ class MetaYaml(HasTraits):
         Description of the dataset.
         """,
     )
-    recipes = Union(
-        [List(Dict()), Dict()],
+    recipes = List(
+        Dict(),
         help="""
         Specifies the deployable Python objects to run in the recipe module.
         If the recipes are assigned to their own Python variable names,
@@ -72,7 +76,7 @@ class MetaYaml(HasTraits):
 
         ```yaml
         recipes:
-          dict_object: "recipe:name_of_recipes_dict"
+          - dict_object: "recipe:name_of_recipes_dict"
         ```
         """,
     )

--- a/tests/unit/test-recipes/dict-recipes/feedstock/meta.yaml
+++ b/tests/unit/test-recipes/dict-recipes/feedstock/meta.yaml
@@ -1,3 +1,3 @@
 title: "Test meta.yaml with list of recipes"
 recipes:
-  dict_object: 'recipe:recipes'
+  - dict_object: 'recipe:recipes'

--- a/tests/unit/test_feedstock.py
+++ b/tests/unit/test_feedstock.py
@@ -32,7 +32,7 @@ def tmp_feedstock(request, tmp_path_factory: pytest.TempPathFactory):
         meta_yaml = dedent(
             """\
         recipes:
-          dict_object: 'recipe:recipes'
+          - dict_object: 'recipe:recipes'
         """
         )
         recipe_py = dedent(

--- a/tests/unit/test_meta_yaml.py
+++ b/tests/unit/test_meta_yaml.py
@@ -54,7 +54,7 @@ def valid_meta_yaml_dict_object(with_recipes_list: str) -> dict:
         dedent(
             """\
         recipes:
-          dict_object: 'recipe:recipes'
+          - dict_object: 'recipe:recipes'
         """
         ),
     )
@@ -109,6 +109,16 @@ def test_missing_recipes_subfield(valid_meta_yaml, subfield):
 def test_recipes_field_cannot_be_empty_container():
     with pytest.raises(TraitError):
         _ = MetaYaml(recipes=[])
+
+
+def test_recipes_field_invalid_keys():
+    with pytest.raises(TraitError):
+        # "dict_object" key can't be used in combination with other keys
+        _ = MetaYaml(recipes={"id": "abcdefg", "dict_object": "abc:def"})
+    with pytest.raises(TraitError):
+        # the only valid keys are {"id", "object"} together,
+        # or "dict_object" alone. other keys are not allowed.
+        _ = MetaYaml(recipes={"some_other_key": "abc:def"})
 
 
 # TODO: In a future "strict" mode, ensure provenance fields are all provided.


### PR DESCRIPTION
This is is a stepping stone between #137 and #139.

It just says that dict_objects, if given, should look like this:


✅ 
```yaml
recipes:
  - dict_object: 'recipe:recipes'
```

and _not_ like this:

❌ 
```yaml
recipes:
  dict_object: 'recipe:recipes'
```

Note the `-` in the former (correct) example.

This is actually bringing us _back into alignment_ with the original spec, which I (mistakenly) revised in:

> https://github.com/pangeo-forge/roadmap/commit/df4b26fe562ebbe58c345a7cf14192c6ff94cc81

The motivation here is that, just because we have `dict_object`s as part of the recipe, we should not be limited to having a single dictionary, or possibly from mixing regular recipe declarations with dict_objects (if we want).

Note that the existence of the schema added in #137 makes it easy to reason about what's allowed and what's not allowed! (That information is not longer obscured in dense procedural code, as it was previously.) 😄 


