### PR TITLE
Upgrade Flink

### DIFF
--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -29,9 +29,10 @@ jobs:
       matrix:
         python-version: [ "3.9", "3.10", "3.11" ]
         recipes-version: [
-            "pangeo-forge-recipes==0.10.0",
+            "pangeo-forge-recipes==0.9.4",
             # save some cycles and infer it might
             # work on all versions between lowest and highest
+            # "pangeo-forge-recipes==0.10.0",
             # "pangeo-forge-recipes==0.10.3",
             "pangeo-forge-recipes==0.10.4",
         ]

--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -42,8 +42,7 @@ jobs:
             # "apache-beam==2.48.0",
             # "apache-beam==2.49.0",
             # "apache-beam==2.50.0",
-            # "apache-beam==2.51.0",
-            "apache-beam==2.52.0",
+            "apache-beam==2.51.0",
         ]
         # keep here to be explicit for future users what version
         # of Flink we are supporting.

--- a/.github/workflows/flink.yaml
+++ b/.github/workflows/flink.yaml
@@ -29,10 +29,9 @@ jobs:
       matrix:
         python-version: [ "3.9", "3.10", "3.11" ]
         recipes-version: [
-            "pangeo-forge-recipes==0.9.4",
+            "pangeo-forge-recipes==0.10.0",
             # save some cycles and infer it might
             # work on all versions between lowest and highest
-            # "pangeo-forge-recipes==0.10.0",
             # "pangeo-forge-recipes==0.10.3",
             "pangeo-forge-recipes==0.10.4",
         ]
@@ -43,10 +42,16 @@ jobs:
             # "apache-beam==2.48.0",
             # "apache-beam==2.49.0",
             # "apache-beam==2.50.0",
-            "apache-beam==2.51.0",
+            # "apache-beam==2.51.0",
+            "apache-beam==2.52.0",
         ]
         # keep here to be explicit for future users what version
-        # of Flink we are supporting
+        # of Flink we are supporting.
+        #
+        # Even though the operator says it's running Flink 1.17
+        # there is no portable runner .jar available yet :scream: :thanksflink:
+        # https://repo.maven.apache.org/maven2/org/apache/beam/beam-runners-flink*
+        # but things seem stable for 1.16 :fingerscrossed:
         flink-version: [ "1.16", ]
 
     steps:
@@ -81,7 +86,10 @@ jobs:
 
     - name: Setup FlinkOperator
       run: |
-        FLINK_OPERATOR_VERSION=1.5.0
+        # as noted here: https://github.com/pangeo-forge/pangeo-forge-cloud-federation/pull/6#issuecomment-1821285529
+        # and more specifically here: https://cwiki.apache.org/confluence/display/FLINK/Release+Schedule+and+Planning
+        # "Support for two (current and previous) releases with bug fixes"
+        FLINK_OPERATOR_VERSION=1.6.1
         helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-${FLINK_OPERATOR_VERSION}
         helm install flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator --wait
 


### PR DESCRIPTION
Addresses #149

NOTE: the [companion PR to upgrade the operator for the TF repo](https://github.com/pangeo-forge/pangeo-forge-cloud-federation/pull/6) will stay with the historyserver updates