### PR TITLE
[Flink] Add option to use JobManager to store history of jobs

### DIFF
--- a/pangeo_forge_runner/bakery/flink.py
+++ b/pangeo_forge_runner/bakery/flink.py
@@ -1,6 +1,7 @@
 """
 Bakery for baking pangeo-forge recipes in GCP DataFlow
 """
+import copy
 import hashlib
 import json
 import shutil
@@ -234,7 +235,7 @@ class FlinkOperatorBakery(Bakery):
         }
 
         # shallow copy
-        new_flink_deploy = current_flink_deploy.copy()
+        new_flink_deploy = copy.deepcopy(current_flink_deploy)
         new_flink_deploy["spec"]["jobManager"].update(pod_template)
         return new_flink_deploy
 

--- a/tests/unit/test_flink.py
+++ b/tests/unit/test_flink.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
+
 import pytest
+
 from pangeo_forge_runner.bakery.flink import FlinkOperatorBakery
 
 

--- a/tests/unit/test_flink.py
+++ b/tests/unit/test_flink.py
@@ -41,7 +41,8 @@ def test_make_flink_deployment(enabled_job_archiving, deploy_name, container_ima
     :return:
     """
 
-    fbake = FlinkOperatorBakery(enabled_job_archiving=enabled_job_archiving)
+    fbake = FlinkOperatorBakery
+    fbake.enable_job_archiving = enabled_job_archiving
     manifest = fbake.make_flink_deployment(deploy_name, container_image)
     if enabled_job_archiving:
         pod_template = manifest["spec"]["jobManager"].get("podTemplate")

--- a/tests/unit/test_flink.py
+++ b/tests/unit/test_flink.py
@@ -45,6 +45,6 @@ def test_make_flink_deployment(archiving_enabled, deploy_name, container_image):
         assert pod_template is not None
         for key in ["securityContext", "containers", "initContainers", "volumes"]:
             assert key in pod_template["spec"]
-    if not archiving_enabled:
+    else:
         pod_template = manifest["spec"]["jobManager"].get("podTemplate")
         assert pod_template is None

--- a/tests/unit/test_flink.py
+++ b/tests/unit/test_flink.py
@@ -28,29 +28,23 @@ def test_pipelineoptions():
 
 
 @pytest.mark.parametrize(
-    "enabled_job_archiving, deploy_name, container_image",
+    "archiving_enabled, deploy_name, container_image",
     (
         [False, "archive_disabled", "apache/beam_python3.10_sdk:2.51.0"],
         [True, "archive_enabled", "apache/beam_python3.10_sdk:2.51.0"],
     ),
 )
-def test_make_flink_deployment(enabled_job_archiving, deploy_name, container_image):
-    """test paths for enabled job archiving
-
-    :param enabled_job_archiving:
-    :param deploy_name:
-    :param container_image:
-    :return:
-    """
-
-    fbake = FlinkOperatorBakery
-    fbake.enable_job_archiving = enabled_job_archiving
+def test_make_flink_deployment(archiving_enabled, deploy_name, container_image):
+    """test paths for enabled job archiving"""
+    fbake = FlinkOperatorBakery()
+    fbake.enable_job_archiving = archiving_enabled
+    print(deploy_name, container_image)
     manifest = fbake.make_flink_deployment(deploy_name, container_image)
-    if enabled_job_archiving:
+    if archiving_enabled:
         pod_template = manifest["spec"]["jobManager"].get("podTemplate")
         assert pod_template is not None
         for key in ["securityContext", "containers", "initContainers", "volumes"]:
             assert key in pod_template["spec"]
-    if not enabled_job_archiving:
+    if not archiving_enabled:
         pod_template = manifest["spec"]["jobManager"].get("podTemplate")
         assert pod_template is None


### PR DESCRIPTION
Mount EFS to Job Managers so they can archive jobs for historical status lookups

Addresses #122

Related PR: https://github.com/pangeo-forge/pangeo-forge-cloud-federation/pull/6