### PR TITLE
Update bake.py

### DIFF
--- a/pangeo_forge_runner/commands/bake.py
+++ b/pangeo_forge_runner/commands/bake.py
@@ -265,6 +265,7 @@ class Bake(BaseCommand):
                     if requirements_path.exists():
                         extra_options["requirements_file"] = str(requirements_path)
 
+                    self.log.info(f"Job name is {per_recipe_unique_job_name or self.job_name}")
                     pipeline_options = bakery.get_pipeline_options(
                         job_name=(per_recipe_unique_job_name or self.job_name),
                         # FIXME: Bring this in from meta.yaml?

--- a/pangeo_forge_runner/commands/bake.py
+++ b/pangeo_forge_runner/commands/bake.py
@@ -265,7 +265,9 @@ class Bake(BaseCommand):
                     if requirements_path.exists():
                         extra_options["requirements_file"] = str(requirements_path)
 
-                    self.log.info(f"Job name is {per_recipe_unique_job_name or self.job_name}")
+                    self.log.info(
+                        f"Job name is {per_recipe_unique_job_name or self.job_name}"
+                    )
                     pipeline_options = bakery.get_pipeline_options(
                         job_name=(per_recipe_unique_job_name or self.job_name),
                         # FIXME: Bring this in from meta.yaml?


### PR DESCRIPTION
Log job name so it can be referenced by users. For veda-pforge-job-runner we use the job_name as part of the bucket output directory (see https://github.com/NASA-IMPACT/veda-pforge-job-runner/blob/main/.github/workflows/config.py#L131).