### PR TITLE
FLINK: force prometheus annotations in the taskmanager manifest

### DIFF
--- a/pangeo_forge_runner/bakery/flink.py
+++ b/pangeo_forge_runner/bakery/flink.py
@@ -267,6 +267,8 @@ class FlinkOperatorBakery(Bakery):
                         "spec": {
                             "containers": [
                                 {
+                                    "name": "flink-main-container",
+                                    "image": f"flink:{self.flink_version}",
                                     "ports": [{
                                         "containerPort": 9999,
                                         "name": "metrics",
@@ -293,6 +295,9 @@ class FlinkOperatorBakery(Bakery):
                                     "image": worker_image,
                                     "ports": [{
                                         "containerPort": 50000
+                                    },{
+                                        "containerPort": 9999,
+                                        "name": "metrics",
                                     }],
                                     "readinessProbe": {
                                         # Don't mark this container as ready until the beam SDK harnass starts

--- a/pangeo_forge_runner/bakery/flink.py
+++ b/pangeo_forge_runner/bakery/flink.py
@@ -257,17 +257,46 @@ class FlinkOperatorBakery(Bakery):
                 "serviceAccount": "flink",
                 "jobManager": {
                     "resource": self.job_manager_resources,
+                    "jobTemplate": {
+                        "metadata": {
+                            "annotations": {
+                                "prometheus.io/port": "9999",
+                                "prometheus.io/scrape": "true"
+                            }
+                        },
+                        "spec": {
+                            "containers": [
+                                {
+                                    "ports": [{
+                                        "containerPort": 9999,
+                                        "name": "metrics",
+                                    }]
+                                }
+                            ]
+                        },
+                    },
                 },
                 "taskManager": {
                     "replicas": 5,
                     "resource": self.task_manager_resources,
                     "podTemplate": {
+                        "metadata": {
+                            "annotations": {
+                                "prometheus.io/port": "9999",
+                                "prometheus.io/scrape": "true"
+                            }
+                        },
                         "spec": {
                             "containers": [
                                 {
                                     "name": "beam-worker-pool",
                                     "image": worker_image,
-                                    "ports": [{"containerPort": 50000}],
+                                    "ports": [{
+                                        "containerPort": 50000
+                                    }, {
+                                        "containerPort": 9999,
+                                        "name": "metrics",
+                                    }],
                                     "readinessProbe": {
                                         # Don't mark this container as ready until the beam SDK harnass starts
                                         "tcpSocket": {"port": 50000},

--- a/pangeo_forge_runner/bakery/flink.py
+++ b/pangeo_forge_runner/bakery/flink.py
@@ -293,9 +293,6 @@ class FlinkOperatorBakery(Bakery):
                                     "image": worker_image,
                                     "ports": [{
                                         "containerPort": 50000
-                                    }, {
-                                        "containerPort": 9999,
-                                        "name": "metrics",
                                     }],
                                     "readinessProbe": {
                                         # Don't mark this container as ready until the beam SDK harnass starts
@@ -305,6 +302,14 @@ class FlinkOperatorBakery(Bakery):
                                     "resources": self.beam_executor_resources,
                                     "command": ["/opt/apache/beam/boot"],
                                     "args": ["--worker_pool"],
+                                },
+                                {
+                                    "name": "flink-main-container",
+                                    "image": f"flink:{self.flink_version}",
+                                    "ports": [{
+                                        "containerPort": 9999,
+                                        "name": "metrics",
+                                    }]
                                 }
                             ]
                         }

--- a/pangeo_forge_runner/bakery/flink.py
+++ b/pangeo_forge_runner/bakery/flink.py
@@ -265,7 +265,7 @@ class FlinkOperatorBakery(Bakery):
                         "metadata": {
                             "annotations": {
                                 "prometheus.io/port": "9999",
-                                "prometheus.io/scrape": "true"
+                                "prometheus.io/scrape": "true",
                             }
                         },
                         "spec": {
@@ -273,12 +273,13 @@ class FlinkOperatorBakery(Bakery):
                                 {
                                     "name": "beam-worker-pool",
                                     "image": worker_image,
-                                    "ports": [{
-                                        "containerPort": 50000
-                                    },{
-                                        "containerPort": 9999,
-                                        "name": "metrics",
-                                    }],
+                                    "ports": [
+                                        {"containerPort": 50000},
+                                        {
+                                            "containerPort": 9999,
+                                            "name": "metrics",
+                                        },
+                                    ],
                                     "readinessProbe": {
                                         # Don't mark this container as ready until the beam SDK harnass starts
                                         "tcpSocket": {"port": 50000},
@@ -291,13 +292,15 @@ class FlinkOperatorBakery(Bakery):
                                 {
                                     "name": "flink-main-container",
                                     "image": f"flink:{self.flink_version}",
-                                    "ports": [{
-                                        "containerPort": 9999,
-                                        "name": "metrics",
-                                    }]
-                                }
+                                    "ports": [
+                                        {
+                                            "containerPort": 9999,
+                                            "name": "metrics",
+                                        }
+                                    ],
+                                },
                             ]
-                        }
+                        },
                     },
                 },
             },

--- a/pangeo_forge_runner/bakery/flink.py
+++ b/pangeo_forge_runner/bakery/flink.py
@@ -257,7 +257,7 @@ class FlinkOperatorBakery(Bakery):
                 "serviceAccount": "flink",
                 "jobManager": {
                     "resource": self.job_manager_resources,
-                    "jobTemplate": {
+                    "podTemplate": {
                         "metadata": {
                             "annotations": {
                                 "prometheus.io/port": "9999",

--- a/pangeo_forge_runner/bakery/flink.py
+++ b/pangeo_forge_runner/bakery/flink.py
@@ -257,26 +257,6 @@ class FlinkOperatorBakery(Bakery):
                 "serviceAccount": "flink",
                 "jobManager": {
                     "resource": self.job_manager_resources,
-                    "podTemplate": {
-                        "metadata": {
-                            "annotations": {
-                                "prometheus.io/port": "9999",
-                                "prometheus.io/scrape": "true"
-                            }
-                        },
-                        "spec": {
-                            "containers": [
-                                {
-                                    "name": "flink-main-container",
-                                    "image": f"flink:{self.flink_version}",
-                                    "ports": [{
-                                        "containerPort": 9999,
-                                        "name": "metrics",
-                                    }]
-                                }
-                            ]
-                        },
-                    },
                 },
                 "taskManager": {
                     "replicas": 5,


### PR DESCRIPTION
#### Addresses
https://github.com/NASA-IMPACT/veda-pforge-job-runner/issues/23
https://github.com/pangeo-forge/pangeo-forge-cloud-federation/issues/24


#### Problem
Our default `flink-conf.yaml` should be able to list global annotations (see [here](https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/deployment/config/#kubernetes-jobmanager-annotations)) we want applied to all task/job managers. However the operator pukes on many different configurations as unparseable and even if you fix those then the deployments of jobs fail for unparseable other reasons. 


#### Solution
So this is a good work around just so we can get metrics on the taskmanager. The job manager wouldn't take any of these force values in their `podTemplate` so not worrying about that for how



